### PR TITLE
Polishment 03272026

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ Compatability.
 
 ## Are you sure the code/proof is 100% correct?
 No. Successful `Qed`s are still false positives, due to a lot of delicate details. For example: 
-- `Ltac` isn't well designed
 - Some propositions are written in natural language
-- I didn't deeply examine the code in chapter 1 - 5
 - Our current implementation doesn't enforce types on propositions.
 
 ## Can Principia Mathematica be completely formalized?

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Yes.
 With [SEP entry for Principia Mathematica](https://plato.stanford.edu/entries/principia-mathematica/), there are already a lot of materials to help formalizing Principia Mathematica. Our project already covers the foundation of the rewriting system with which all advanced mathematical ideas are built on.
 
 Beneath the code and down to the core, the difficulty in formalization is how PM organizes its ideas. This means:
-- PM gets a mountain of notations, symbols, theorems, and different contexts to interpret them. See [What are the real problems to formalize Principia Mathematica?](./docs/3_mechanics.md/#what-are-the-real-problems-to-formalize-principia-mathematica)
+- PM gets a mountain of notations, symbols, theorems, and different contexts to interpret them. See [What are the actual problems to formalize Principia Mathematica?](./docs/3_mechanics.md/#what-are-the-actual-problems-to-formalize-principia-mathematica)
 - Terminologies also have different meanings in different chapters, and the range of the distinction is a manual work. For example, "functions" and "matrices"
 
 [This awesome blog](https://lawrencecpaulson.github.io/tag/Principia_Mathematica) has presented a series of critiques on PM. [Some of these critiques](https://lawrencecpaulson.github.io/2025/10/15/Proofs-trivial.html) pretty much summarize what we have seen so far: PM's notorious notation system, highly "trivial"(chores-like) theorems, and its historical background to guarantee a missing revisit.

--- a/docs/1_overview.md
+++ b/docs/1_overview.md
@@ -18,7 +18,6 @@ I started this project by
 - [x] Making chapter 1 - 5 of Landon's original repository into a Rocq project
 - [x] Simplifying `Nicod1_4.v`, `Yuelin.v`, `Jorgensen3_47.v`, `Lemma5_7.v`, cutting down 20% of their LoC and greatly enhance readability
 - [x] Simplifying, bug-picking chapter 1 - 5, cutting down \~1k LoC in total
-- [x] Summary on rest of the works can be found at the beginning of [mechanics](./3_mechanics.md).
 
 ## Project status
 We are building: 

--- a/docs/1_overview.md
+++ b/docs/1_overview.md
@@ -18,6 +18,7 @@ I started this project by
 - [x] Making chapter 1 - 5 of Landon's original repository into a Rocq project
 - [x] Simplifying `Nicod1_4.v`, `Yuelin.v`, `Jorgensen3_47.v`, `Lemma5_7.v`, cutting down 20% of their LoC and greatly enhance readability
 - [x] Simplifying, bug-picking chapter 1 - 5, cutting down \~1k LoC in total
+- [x] Redesigning custom `Ltac`s in chapter 1 - 5 to their perfection, eliminating all incorrect `Ltac` usages once and for all, plus cleanups like `clean`/`move` that were once necessary
 
 ## Project status
 We are building: 

--- a/docs/1_overview.md
+++ b/docs/1_overview.md
@@ -18,7 +18,7 @@ I started this project by
 - [x] Making chapter 1 - 5 of Landon's original repository into a Rocq project
 - [x] Simplifying `Nicod1_4.v`, `Yuelin.v`, `Jorgensen3_47.v`, `Lemma5_7.v`, cutting down 20% of their LoC and greatly enhance readability
 - [x] Simplifying, bug-picking chapter 1 - 5, cutting down \~1k LoC in total
-- [x] Redesigning custom `Ltac`s in chapter 1 - 5 to their perfection, eliminating all incorrect `Ltac` usages once and for all, plus cleanups like `clean`/`move` that were once necessary
+- [x] Redesigning custom `Ltac`s in chapter 1 - 5 to their perfection, eliminating all incorrect `Ltac` usages once and for all, plus cleanups like `clear`/`move` that were once necessary
 
 ## Project status
 We are building: 

--- a/docs/3_mechanics.md
+++ b/docs/3_mechanics.md
@@ -34,9 +34,9 @@ Our implementation seems to arise awareness to *how well does symbols of PM work
 3. Can we design a set of notations that can work well altogether?
 4. For current implementation, can we give correct types to parameters? For example, is it really that function's type should be just `Prop -> Prop`, when the difference between untyped functions and predicative functions become more and more significant in later chapters?
 
-These problems will not be discussed in this chapter, but can be inferred from analytics in [audit](./5_audit.md).
+Such purpose can be alleviated to a degree, if we are not insisting on using the symbols in PM. For example see [Randall's](https://github.com/Randall-Holmes/Randall-Holmes.github.io/tree/master/RTT) suggestion on alternative symbols. The problems listed above will not be discussed in this chapter, but can be inferred from analytics in [audit](./5_audit.md).
 
-We now start explaining what are the main ideas for each chapters.
+We now start exploring the main ideas for each chapters.
 
 ## Chapters
 ### Chapter 1

--- a/docs/3_mechanics.md
+++ b/docs/3_mechanics.md
@@ -27,8 +27,8 @@ During each steps of the proof, Principia **cites** the theorems and previous st
 
 Context to prove theorems, like symbol definitions, have its **inheriting** nature. Theorems are proven in different context between different chapters. See [chapter 1](./3_mechanics.md/#chapter-1) for case in chapter 1 - 5, [chapter 9](./3_mechanics.md/#chapter-9) for case in chapter 9 - 11, [chapter 12](./3_mechanics.md/#chapter-12) for chapter 12 - 14, [chapter 20](./3_mechanics.md/#chapter-20) for beyond.
 
-### What are the real problems to formalize Principia Mathematica?
-Our implementation seems to arise awareness to *how well does notions of PM work with each other*. This means to the following:
+### What are the actual problems to formalize Principia Mathematica?
+Our implementation seems to arise awareness to *how well does symbols of PM work together*. This means to the following:
 1. Can we design the correct type system for PM, since PM doesn't explicitly type the propositions?
 2. Can we distinguish different contexts for theorems in different chapters, since their validity is proven in different context?
 3. Can we design a set of notations that can work well altogether?
@@ -36,7 +36,7 @@ Our implementation seems to arise awareness to *how well does notions of PM work
 
 These problems will not be discussed in this chapter, but can be inferred from analytics in [audit](./5_audit.md).
 
-We now start explaining what new ideas are being introduced into each of the chapters.
+We now start explaining what are the main ideas for each chapters.
 
 ## Chapters
 ### Chapter 1

--- a/docs/4_tactics.md
+++ b/docs/4_tactics.md
@@ -94,18 +94,14 @@ Either for "historical reasons"(this project really doesn't have a history), or 
 - \[Simplification\]`now tactic thm ...` says that, if the `tactic` we use can directly provide a result that is not very far from the goal, then we prove the goal immediately. Typically it's very useful for saving a line of `exact thm`. Every line of `now tactic thm` can be turned back into `tactic thm` for readers to check if it does indeed generate a proposition that is exactly the same as the goal, and this tactic is **recommended** to use.
 - \[Simplification\]Further exceptions not being listed above, for example in chapter 11, have to be explicitly stated with a comment that a simplification has happened. This is **recommended** to be taken down in the future.
 
-## Bugged Ltacs
-Throughout chapter 1 - 5, there are several custom tactics defined to use the primitive ideas conveniently. However, their current design is bugged: when we're trying to use them, they might not find the exact propositions that we are referring to. If things has gone very bad, here is the full steps for just applying one tactic safely:
-1. `assert` a subgoal for the desired proposition
-2. `clear` every unrelated hypotheses
-3. `move` the propositions `before` or `after`, into the right order. For example, if we want to `MP S2 S1`, then we have to `move S1 after S2`.
-4. perform the tactic and immediately conclude the subproof.
-
-Since we don't always need to go through the full steps, we're only requiring that
-- Tactics above are **allowed** to use, when necessary to ensure correctness.
-
-## Debugging the proof
+## Ltacs for debugging/prettify the goal window
 It happens that users might want to check the proofs in more detail. How to debug the proof is completely personal, but here are some tactics I commonly use, just in case:
 - `simpl` to simplify a hypothesis
 - `Close Scope`/`Open Scope` to enable/disable specific notations. We have designed specific notations for debugging in later chapters.
 - `pose proof` another theorem to see how it looks like originally
+
+There are also some other tactics that makes the goal window just a bit prettier, for example:
+- `move` to rearrange the order of hypotheses
+- `clear` to remove some hypothesis that will never be used
+
+- Tactics above is **recommended** to be reduced to minimum when we have finished them.

--- a/pm/ch1.v
+++ b/pm/ch1.v
@@ -61,7 +61,6 @@ Proof.
   { right. right. apply H. }
 Qed.
 
-
 Theorem Sum1_6 (P Q R : Prop) : 
   (Q → R) → (P ∨ Q → P ∨ R). (*Summation*)
 Proof. 

--- a/pm/ch1.v
+++ b/pm/ch1.v
@@ -11,17 +11,26 @@ Qed.
   It is used to switch between "∨" and "→". *)
   
 (* Pp. 1.1: Anything implied by a true elementary proposition is true *)
+
+(* Pp. 1.11: Modus ponens *)
 (* Although being written down informally, designing an ltac to pick the 
   right and asserted hypothesis and produce a new hypothesis, is exactly what
   Principia wants to do. Since it will be used very frequently we omit the 
   number for this Ltac *)
 Ltac MP H1 H2 :=
-  lazymatch goal with 
-    | [ H1 : ?P → ?Q, H2 : ?P |- _ ] => 
-      pose proof (H1 H2) as H1; simpl in H1
+  match goal with 
+  | [ _H1 : ?P → ?Q |- _ ] => 
+    constr_eq H1 _H1;
+    pose proof (H1 H2) as H1; 
+    simpl in H1
   end.
 
-(* *1.11 ommitted: it is MP for propositions containing variables. *)
+Ltac MP_debug H1 H2 D1 D2 :=
+  match goal with 
+  | [ _H1 : ?P → ?Q |- _ ] => 
+    constr_eq H1 _H1;
+    assert (D1 : P) by admit
+  end.
 
 Theorem Taut1_2 (P : Prop) :
   P ∨ P → P. (*Tautology*)

--- a/pm/ch10.v
+++ b/pm/ch10.v
@@ -119,7 +119,7 @@ Proof.
   { 
     move S3 after S4.
     clear S1 S2.
-    Conj S4 S3 C1.
+    Conj_as S4 S3 C1.
     now Equiv C1.
    }
   exact S5.
@@ -145,7 +145,7 @@ Proof.
   assert (S2 : (∀ x, φ x ∧ ψ x) → φ Y).
   { 
     pose proof (Simp3_26 (φ Y) (ψ Y)) as Simp3_26.
-    now Syll S1 Simp3_26 S2.
+    now Syll_as S1 Simp3_26 S2.
   }
   assert (S3 : (∀ y, (∀ x, φ x ∧ ψ x) → φ y)).
   {
@@ -157,7 +157,7 @@ Proof.
   assert (S5 : (∀ x, φ x ∧ ψ x) → ψ Y).
   {
     pose proof (Simp3_27 (φ Y) (ψ Y)) as Simp3_27.
-    now Syll S1 Simp3_27 S5.
+    now Syll_as S1 Simp3_27 S5.
   }
   assert (S6 : (∀ y, (∀ x, φ x ∧ ψ x) → ψ y)).
   {
@@ -171,7 +171,7 @@ Proof.
     pose proof (Comp3_43 (∀ x, φ x ∧ ψ x) (∀ y, φ y) (∀ z, ψ z)) as Comp3_43.
     assert (C1 : ((∀ x, φ x ∧ ψ x) → ∀ y, φ y)
       ∧ ((∀ x, φ x ∧ ψ x) → ∀ y, ψ y)).
-    { clear S1 S2 S3 S5 S6 Comp3_43. now Conj S4 S7 C1. }
+    { clear S1 S2 S3 S5 S6 Comp3_43. now Conj_as S4 S7 C1. }
     now MP Comp3_43 C1.
   }
   assert (S9 : ∀ y, (∀ x, φ x) ∧ (∀ x, ψ x) → (φ y ∧ ψ y)).
@@ -192,7 +192,7 @@ Proof.
       ∧ ((∀ x, φ x) ∧ (∀ x, ψ x) → ∀ y, (φ y ∧ ψ y))).
     {
       clear S1 S2 S3 S4 S5 S6 S7 S9.
-      now Conj S8 S10 C1.
+      now Conj_as S8 S10 C1.
     }
     now Equiv C1.
   }
@@ -240,7 +240,7 @@ Proof.
     rewrite <- (n4_13 (∀ x, ¬ φ x)) in Transp2_17.
     assert (C1 : (((∃ x, φ x) → P) → (¬ P → ∀ x, ¬ φ x))
       ∧ ((¬ P → ∀ x, ¬ φ x) → ((∃ x, φ x) → P))).
-    { now Conj Transp2_16 Transp2_17 C1. }
+    { now Conj_as Transp2_16 Transp2_17 C1. }
     Equiv C1.
     exact C1.
   }
@@ -254,12 +254,12 @@ Proof.
   {
     pose proof (n10_1 (fun x => (¬ P) → ¬ φ x) X) as n10_1.
     destruct S2 as [S2_l _].
-    now Syll S2_l n10_1 S3.
+    now Syll_as S2_l n10_1 S3.
   }
   assert (S4 : ((∃ x, φ x) → P) → (φ X → P)).
   {
     pose proof (Transp2_17 (φ X) P) as Transp2_17.
-    now Syll S3 Transp2_17 S4.
+    now Syll_as S3 Transp2_17 S4.
   }
   (* The variable naming here is so wild *)
   assert (S5 : ∀ x0, ((∃ x, φ x) → P) → (φ x0 → P)).
@@ -278,7 +278,7 @@ Proof.
   assert (S8 : (∀ x, (φ x → P)) → ((¬ P) → ¬ φ X)).
   {
     pose proof (Transp2_16 (φ X) P) as Transp2_16.
-    now Syll S7 Transp2_16 S8.
+    now Syll_as S7 Transp2_16 S8.
   }
   assert (S9 : (∀ x, (φ x → P)) → (∀ x, (¬ P) → ¬ φ x)).
   {
@@ -288,20 +288,20 @@ Proof.
     maybe there's even better and more natural way to handle this *)
     {
       intro Hp.
-      Syll Hp n10_11 H0.
+      Syll_as Hp n10_11 H0.
       exact H0.
     }
-    Syll S8 S8_1 S8_2.
+    Syll_as S8 S8_1 S8_2.
     pose proof (n10_21 (fun x => ¬ φ x) (¬ P)) as n10_21.
     destruct n10_21 as [_ n10_21].
     clear S1 S2 S3 S4 S5 S6 S7 n10_11 S8 S8_1.
-    now Syll S8_2 n10_21 S9.
+    now Syll_as S8_2 n10_21 S9.
   }
   assert (S10 : (∀ x, (φ x → P)) → (∃ x, φ x) → P).
   {
     destruct S2 as [_ S2].
     clear S1 S3 S4 S5 S6 S7 S8.
-    now Syll S9 S2 S10.
+    now Syll_as S9 S2 S10.
   }
   assert (S11 : (∀ x, φ x → P) ↔ ((∃ x, φ x) → P)).
   {
@@ -310,7 +310,7 @@ Proof.
     {
       clear S1 S2 S3 S4 S5 S7 S8 S9.
       move S10 after S6.
-      now Conj S10 S6 C1.
+      now Conj_as S10 S6 C1.
     }
     now Equiv C1.
   }
@@ -337,7 +337,7 @@ Proof.
   set (Y := Intro_individual "y").
   pose proof (n10_1 φ Y) as n10_1.
   pose proof (n10_24 φ Y) as n10_24.
-  now Syll n10_1 n10_24 S1.
+  now Syll_as n10_1 n10_24 S1.
 Qed.
 
 Theorem n10_251 (φ : Prop → Prop) : (∀ x, ¬ φ x) → ¬ (∀ x, φ x).
@@ -348,7 +348,7 @@ Proof.
   MP Transp2_16 n10_25.
   rewrite -> n10_01 in Transp2_16.
   pose proof (n2_12 ((∀ x, ¬ φ x))) as n2_12.
-  now Syll n2_12 Transp2_16 S1.
+  now Syll_as n2_12 Transp2_16 S1.
 Qed.
 
 Theorem n10_252 (φ : Prop → Prop) : ¬ (∃ x, φ x) ↔ (∀ x, ¬ φ x).
@@ -382,13 +382,13 @@ Proof.
   assert (S2 : (∀ x, φ x) → ¬¬ φ Y).
   {
     pose proof (n2_12 (φ Y)) as n2_12.
-    now Syll S1 n2_12 S2.
+    now Syll_as S1 n2_12 S2.
   }
   assert (S3 : (∀ x, φ x) → ∀ y, ¬¬ φ y).
   {
     (* n10_21 is unused *)
     pose proof (n10_11 Y (fun y => ¬¬ φ y)) as n10_11.
-    now Syll S2 n10_21 S3.
+    now Syll_as S2 n10_21 S3.
   }
   assert (S4 : (¬ (∀ y, ¬¬ φ y)) → ¬ (∀ x, φ x)).
   {
@@ -404,13 +404,13 @@ Proof.
   assert (S7 : (∀ y, ¬¬ φ y) → φ X).
   {
     pose proof (n2_14 (φ X)) as n2_14.
-    now Syll S6 n2_14 S7.
+    now Syll_as S6 n2_14 S7.
   }
   assert (S8 : (∀ y, ¬¬ φ y) → (∀ x, φ x)).
   {
     (* n10_21 is ignored *)
     pose proof (n10_11 X φ) as n10_11.
-    now Syll S7 n10_11 S8.
+    now Syll_as S7 n10_11 S8.
   }
   assert (S9 : (¬ (∀ x, φ x)) → ¬ (∀ y, ¬¬ φ y)).
   {
@@ -426,7 +426,7 @@ Proof.
     {
       clear S1 S2 S3 S4 S6 S7 S8 S9.
       move S10 after S5.
-      now Conj S10 S5 C1.
+      now Conj_as S10 S5 C1.
     }
     now Equiv C1.
   }
@@ -454,9 +454,9 @@ Proof.
   {
     pose proof (Ass3_35 (φ Y) (ψ Y)) as Ass3_35.
     pose proof (n3_22 (φ Y → ψ Y) (φ Y)) as n3_22.
-    Syll n3_22 Ass3_35 S2.
+    Syll_as n3_22 Ass3_35 S2.
     clear n3_22.
-    now Syll S1 S2 S2_1.
+    now Syll_as S1 S2 S2_1.
   }
   assert (S3 : ∀ y, ((∀ z, φ z → ψ z) ∧ (∀ z, φ z)) → ψ y).
   {
@@ -495,7 +495,7 @@ Proof.
   {
     pose proof (Simp3_26 (∀ x, φ x → ψ x) (∀ x, ψ x → φ x)) 
       as Simp3_26.
-    now Syll n10_22l Simp3_26 S1.
+    now Syll_as n10_22l Simp3_26 S1.
   }
   assert (S2 : (∀ z, φ z ↔ ψ z) → ((∀ z, φ z) → (∀ z, ψ z))).
   {
@@ -515,7 +515,7 @@ Proof.
   {
     pose proof (Simp3_27 (∀ x, φ x → ψ x) (∀ x, ψ x → φ x)) 
       as Simp3_27.
-    now Syll n10_22l Simp3_27 S3.
+    now Syll_as n10_22l Simp3_27 S3.
   }
   assert (S4 : (∀ z, φ z ↔ ψ z) → ((∀ z, ψ z) → (∀ z, φ z))).
   {
@@ -529,7 +529,7 @@ Proof.
   {
     assert (C1 : ((∀ z, φ z ↔ ψ z) → ((∀ z, φ z) → (∀ z, ψ z)))
       ∧ ((∀ z, φ z ↔ ψ z) → ((∀ z, ψ z) → (∀ z, φ z)))).
-    { clear n10_22l S1 S3. now Conj S2 S4 C1. }
+    { clear n10_22l S1 S3. now Conj_as S2 S4 C1. }
     pose proof (Comp3_43 (∀ z, φ z ↔ ψ z)
       ((∀ z, φ z) → (∀ z, ψ z))
       ((∀ z, ψ z) → (∀ z, φ z))
@@ -551,7 +551,7 @@ Proof.
   assert (S2 : (∀ x, φ x → ψ x) → ((¬ ψ Y) → (¬ φ Y))).
   {
     pose proof (Transp2_16 (φ Y) (ψ Y)) as Transp2_16.
-    now Syll S1 Transp2_16 S2.
+    now Syll_as S1 Transp2_16 S2.
   }
   assert (S3 : (∀ x, φ x → ψ x) → ∀ y, (¬ ψ y) → (¬ φ y)).
   {
@@ -564,12 +564,12 @@ Proof.
   assert (S4 : (∀ x, φ x → ψ x) → ((∀ y, ¬ ψ y) → (∀ y, ¬ φ y))).
   {
     pose proof (n10_27 (fun y => ¬ ψ y) (fun y => ¬ φ y)) as n10_27.
-    now Syll S3 n10_27 S4.
+    now Syll_as S3 n10_27 S4.
   }
   assert (S5 : (∀ x, φ x → ψ x) → ((∃ y, φ y) → (∃ y, ψ y))).
   {
     pose proof (Transp2_16 (∀ y, ¬ ψ y) (∀ y, ¬ φ y)) as Transp2_16.
-    Syll S4 Transp2_16 S5.
+    Syll_as S4 Transp2_16 S5.
     now repeat rewrite <- n10_01 in S5.
   }
   exact S5.
@@ -594,18 +594,18 @@ Proof.
   {
     pose proof (Simp3_26 (∀ x, φ x → ψ x) (∀ x, ψ x → φ x))
       as Simp3_26.
-    Syll n10_22l Simp3_26 n10_22l1.
+    Syll_as n10_22l Simp3_26 n10_22l1.
     pose proof (n10_28 φ ψ) as n10_28a.
-    now Syll n10_22l1 n10_28a Sa.
+    now Syll_as n10_22l1 n10_28a Sa.
   }
   assert (Sb : (∀ x, φ x ↔ ψ x) →
     (∃ x, ψ x) → (∃ x, φ x)).
   {
     pose proof (Simp3_27 (∀ x, φ x → ψ x) (∀ x, ψ x → φ x))
       as Simp3_27.
-    Syll n10_22l Simp3_27 n10_22l2.
+    Syll_as n10_22l Simp3_27 n10_22l2.
     pose proof (n10_28 ψ φ) as n10_28b.
-    now Syll n10_22l2 n10_28b Sb.
+    now Syll_as n10_22l2 n10_28b Sb.
   }
   pose proof (Comp3_43 (∀ x, φ x ↔ ψ x)
     ((∃ x, φ x) → (∃ x, ψ x))
@@ -615,15 +615,15 @@ Proof.
     ∧ ((∀ x, φ x ↔ ψ x) → (∃ x, ψ x) → (∃ x, φ x))).
   {
     clear Equiv4_01a n10_22l Comp3_43.
-    now Conj Sa Sb C1.
+    now Conj_as Sa Sb C1.
   }
   MP Comp3_43 C1.
   assert (Sc : (∀ x, φ x → ψ x) ∧ (∀ x, ψ x → φ x)
     → ((∃ x, φ x) → ∃ x, ψ x) ∧ ((∃ x, ψ x) → ∃ x, φ x)).
-  { clear n10_22l. now Syll n10_22r Comp3_43 Sc. }
+  { clear n10_22l. now Syll_as n10_22r Comp3_43 Sc. }
   setoid_rewrite <- Equiv4_01a in Sc.
   assert (Sd : (∀ x, φ x ↔ ψ x) → (∃ x, φ x) ↔ ∃ x, ψ x).
-  { clear n10_22r. now Syll n10_22r Sc Sd. }
+  { clear n10_22r. now Syll_as n10_22r Sc Sd. }
   exact Sd.
 Qed.
 
@@ -666,7 +666,7 @@ Proof.
         ↔ (∀ x, (φ x → ψ x) ∧ (φ x → χ x)))
       ∧ ((∀ x, (φ x → ψ x) ∧ (φ x → χ x))
          ↔ (∀ x, φ x → (ψ x ∧ χ x)))).
-    { clear S2 S3. now Conj S1 S4 C1. }
+    { clear S2 S3. now Conj_as S1 S4 C1. }
     pose proof (n4_22
       ((∀ x, φ x → ψ x) ∧ (∀ x, φ x → χ x))
       (∀ x, (φ x → ψ x) ∧ (φ x → χ x))
@@ -828,7 +828,7 @@ Proof.
       ∧
       ((φ x -[1 x ]> ψ x) ∧ (ψ x -[1 x ]> φ x) ↔
       (ψ x -[1 x ]> φ x) ∧ (φ x -[1 x ]> ψ x))).
-    { now Conj S1 n4_3 C1. }
+    { now Conj_as S1 n4_3 C1. }
     pose proof (n4_22
       ((φ x) <[1- x -]> (ψ x))
       (((φ x) -[1 x ]> (ψ x)) ∧ ((ψ x) -[1 x ]> (φ x)))
@@ -848,7 +848,7 @@ Proof.
       ∧
       (((ψ x -[1 x ]> φ x) ∧ (φ x -[1 x ]> ψ x)) 
         ↔ ∀ x, (ψ x → φ x) ∧ (φ x → ψ x))).
-    { now Conj S2 n10_22 C1. }
+    { now Conj_as S2 n10_22 C1. }
     pose proof (n4_22
       (φ x <[1- x -]> ψ x)
       ((ψ x -[1 x ]> φ x) ∧ (φ x -[1 x ]> ψ x))
@@ -924,12 +924,12 @@ Proof.
   assert (S2 : (∀ x, φ x ∧ P) → P).
   {
     pose proof (Simp3_27 (φ Y) P) as Simp3_27.
-    now Syll S1 Simp3_27 S2.
+    now Syll_as S1 Simp3_27 S2.
   }
   assert (S3 : (∀ x, φ x ∧ P) → φ Y).
   { 
     pose proof (Simp3_26 (φ Y) P) as Simp3_26.
-    now Syll S1 Simp3_26 S3.
+    now Syll_as S1 Simp3_26 S3.
   }
   assert (S4 : (∀ x, φ x ∧ P) → (∀ y, φ y)).
   {
@@ -945,7 +945,7 @@ Proof.
     {
       clear S1 S3.
       move S2 after S4.
-      now Conj S4 S2 C1.
+      now Conj_as S4 S2 C1.
     }
     now rewrite -> (n4_76 (∀ x, φ x ∧ P) (∀ y, φ y) P) in C1.
   }
@@ -970,7 +970,7 @@ Proof.
   {
     clear S1 S2 S3 S4 S6 S7.
     move S5 after S8.
-    Conj S8 S5 S9.
+    Conj_as S8 S5 S9.
     now Equiv S9.
   }
   exact S9.
@@ -1040,12 +1040,12 @@ Proof.
   {
     (* n10_21 ignored - seems completely unnecessary *)
     pose proof (n10_11 X (fun x => φ x → (P ∧ φ x))) as n10_11.
-    now Syll n10_11 S7 S8.
+    now Syll_as n10_11 S7 S8.
   }
   assert (S9 : P → ((∃ x, φ x) → (∃ x, P ∧ φ x))).
   {
     pose proof (n10_28 φ (fun x => P ∧ φ x)) as n10_28.
-    now Syll n10_28 S8 S9.
+    now Syll_as n10_28 S8 S9.
   }
   assert (S10 : (∃ x, P ∧ φ x) ↔ P ∧ (∃ x, φ x)).
   {
@@ -1055,13 +1055,13 @@ Proof.
     MP Imp3_31 S9.
     assert (C1 : ((∃ x, P ∧ φ x) → P) 
       ∧ ((∃ x, P ∧ φ x) → ∃ x, φ x)).
-    { now Conj S3 S6 C1. }
+    { now Conj_as S3 S6 C1. }
     pose proof (Comp3_43 (∃ x, P ∧ φ x) P (∃ x, φ x))
       as Comp3_43.
     MP Comp3_43 C1.
     assert (C2 : ((∃ x, P ∧ φ x) → P ∧ ∃ x, φ x)
       ∧ (P ∧ (∃ x, φ x) → ∃ x, P ∧ φ x)).
-    { now Conj Comp3_43 Imp3_31 C2. }
+    { now Conj_as Comp3_43 Imp3_31 C2. }
     now Equiv C2.
   }
   exact S10.
@@ -1146,7 +1146,7 @@ Proof.
       (fun x => (φ x ∧ ψ x → χ x ∧ θ x))
     ) as n10_27.
     MP n10_27 n10_11.
-    now Syll S1 n10_27 S2.
+    now Syll_as S1 n10_27 S2.
   }
   exact S2.
 Qed.
@@ -1173,14 +1173,14 @@ Proof.
   {
     pose proof (Simp3_26 (φ x -[1 x ]> χ x) (χ x -[1 x ]> φ x))
       as Simp3_26a.
-    Syll n10_22al Simp3_26a n10_22al_1.
+    Syll_as n10_22al Simp3_26a n10_22al_1.
     pose proof (Simp3_26 (ψ x -[1 x ]> θ x) (θ x -[1 x ]> ψ x))
       as Simp3_26b.
-    Syll n10_22bl Simp3_26b n10_22bl_1.
+    Syll_as n10_22bl Simp3_26b n10_22bl_1.
     clear n10_22al n10_22bl Simp3_26a Simp3_26b.
     assert (C1 : ((φ x <[1- x -]> χ x) → (φ x -[1 x ]> χ x))
       ∧ ((ψ x <[1- x -]> θ x) → (ψ x -[1 x ]> θ x))).
-    { now Conj n10_22al_1 n10_22bl_1 C1. }
+    { now Conj_as n10_22al_1 n10_22bl_1 C1. }
     pose proof (n3_47 
       (φ x <[1- x -]> χ x) (ψ x <[1- x -]> θ x)
       (φ x -[1 x ]> χ x) (ψ x -[1 x ]> θ x))
@@ -1191,28 +1191,28 @@ Proof.
     → (φ x ∧ ψ x) -[1 x ]> (χ x ∧ θ x)).
   {
     pose proof (n10_39 φ ψ χ θ) as n10_39.
-    now Syll n10_39 S1 S2.
+    now Syll_as n10_39 S1 S2.
   }
   assert (S3 : ((φ x <[1- x -]> χ x) ∧ ((ψ x <[1- x -]> θ x)))
     → (χ x ∧ θ x) -[1 x ]> (φ x ∧ ψ x)).
   {
     pose proof (Simp3_27 (φ x -[1 x ]> χ x) (χ x -[1 x ]> φ x))
       as Simp3_27a.
-    Syll n10_22al Simp3_27a n10_22al_1.
+    Syll_as n10_22al Simp3_27a n10_22al_1.
     pose proof (Simp3_27 (ψ x -[1 x ]> θ x) (θ x -[1 x ]> ψ x))
       as Simp3_27b.
-    Syll n10_22bl Simp3_27b n10_22bl_1.
+    Syll_as n10_22bl Simp3_27b n10_22bl_1.
     clear n10_22al n10_22bl Simp3_27a Simp3_27b.
     assert (C1 : ((φ x <[1- x -]> χ x) → (χ x -[1 x ]> φ x))
       ∧ ((ψ x <[1- x -]> θ x) → (θ x -[1 x ]> ψ x))).
-    { now Conj n10_22al_1 n10_22bl_1 C1. }
+    { now Conj_as n10_22al_1 n10_22bl_1 C1. }
     pose proof (n3_47
       (φ x <[1- x -]> χ x) (ψ x <[1- x -]> θ x)
       (χ x -[1 x ]> φ x) (θ x -[1 x ]> ψ x)
     ) as n3_47.
     MP n3_47 C1.
     pose proof (n10_39 χ θ φ ψ) as n10_39.
-    now Syll n3_47 n10_39 S3.
+    now Syll_as n3_47 n10_39 S3.
   }
   assert (S4 : ((φ x <[1- x -]> χ x) ∧ ((ψ x <[1- x -]> θ x)))
     → (((φ x ∧ ψ x) -[1 x ]> (χ x ∧ θ x))
@@ -1224,7 +1224,7 @@ Proof.
       ∧
       ((φ x <[1- x -]> χ x) ∧ (ψ x <[1- x -]> θ x)
         → ((χ x ∧ θ x) -[1 x ]> φ x ∧ ψ x))).
-    { now Conj S1 S3 C1. }
+    { now Conj_as S1 S3 C1. }
     pose proof (Comp3_43
       ((φ x <[1- x -]> χ x) ∧ ((ψ x <[1- x -]> θ x)))
       ((φ x ∧ ψ x) -[1 x ]> (χ x ∧ θ x))
@@ -1254,14 +1254,14 @@ Proof.
   assert (S2 : (∀ x, φ x) → (φ Y ∨ ψ Y)).
   {
     pose proof (n2_2 (φ Y) (ψ Y)) as n2_2.
-    now Syll S1 n2_2 S2.
+    now Syll_as S1 n2_2 S2.
   }
   assert (S3 : (∀ x, ψ x) → ψ Y).
   { now apply n10_1. }
   assert (S4 : (∀ x, ψ x) → (φ Y ∨ ψ Y)).
   {
     pose proof (Add1_3 (φ Y) (ψ Y)) as Add1_3.
-    now Syll S2 Add1_3 S3.
+    now Syll_as S2 Add1_3 S3.
   }
   assert (S5 : ((∀ x, φ x) → (φ Y ∨ ψ Y))
     ∧ ((∀ x, ψ x) → (φ Y ∨ ψ Y))).
@@ -1310,7 +1310,7 @@ Proof.
     → ((φ X ∨ ψ X) ↔ (χ X ∨ θ X))).
   {
     pose proof (n4_39 (φ X) (ψ X) (χ X) (θ X)) as n4_39.
-    now Syll n4_39 S1 S2.
+    now Syll_as n4_39 S1 S2.
   }
   assert (S3 : ((φ x <[1- x -]> χ x) ∧ ((ψ x <[1- x -]> θ x)))
     → (φ x ∨ ψ x) <[1- x -]> (χ x ∨ θ x)).
@@ -1390,7 +1390,7 @@ Proof.
       ∧
       ((φ x <[1- x -]> χ x) ∧ (ψ x <[1- x -]> θ x) →
         (φ x → ψ x) <[1- x -]> (χ x → θ x))).
-    { now Conj S1 n10_413 C1. }
+    { now Conj_as S1 n10_413 C1. }
     pose proof (n10_4
       (fun x => ψ x → φ x)
       (fun x => φ x → ψ x)
@@ -1404,7 +1404,7 @@ Proof.
       ) as n4_76.
     rewrite -> n4_76 in C1.
     clear S1 n10_413 n4_76.
-    Syll C1 n10_4 S1_1.
+    Syll_as C1 n10_4 S1_1.
     setoid_rewrite <- Equiv4_01a in S1_1.
     (* Change the orders in conclusion *)
     setoid_rewrite -> n4_21 in S1_1 at 4.
@@ -1490,7 +1490,7 @@ Proof.
   {
     assert (C1 : ((∃ x, φ x ∧ ψ x) → ∃ x, φ x)
       ∧ ((∃ x, φ x ∧ ψ x) → ∃ x, ψ x)).
-    { now Conj S2 S4 C1. }
+    { now Conj_as S2 S4 C1. }
     pose proof (Comp3_43 (∃ x, φ x ∧ ψ x) (∃ x, φ x)
       (∃ x, ψ x)) as Comp3_43.
     now MP C1 Comp3_43.
@@ -1620,7 +1620,7 @@ Proof.
     → ((∃ x, φ x ∧ ψ x) ↔ (∃ x, φ x))).
   {
     pose proof (n10_281 (fun x => φ x ∧ ψ x) φ) as n10_281.
-    now Syll S2 n10_281 S3.
+    now Syll_as S2 n10_281 S3.
   }
   assert (S4 : ((∃ x, φ x ∧ ψ x) ∧ (φ x -[1 x ]> ψ x))
     ↔ ((∃ x, φ x) ∧ (φ x -[1 x ]> ψ x))).
@@ -1645,7 +1645,7 @@ Proof.
   {
     pose proof (n10_28 (fun x => (φ x ∧ χ x)) 
       (fun x => ψ x ∧ χ x)) as n10_28.
-    now Syll S1 n10_28 S2.
+    now Syll_as S1 n10_28 S2.
   }
   assert (S3 : ((φ x -[1 x ]> ψ x) ∧ (∃ x, φ x ∧ χ x))
     → (∃ x, ψ x ∧ χ x)).

--- a/pm/ch10.v
+++ b/pm/ch10.v
@@ -117,8 +117,6 @@ Proof.
   { exact (n10_12 φ P). }
   assert (S5 : (∀ x, P ∨ φ x) ↔ P ∨ (∀ x, φ x)).
   { 
-    move S3 after S4.
-    clear S1 S2.
     Conj_as S4 S3 C1.
     now Equiv C1.
    }
@@ -169,9 +167,7 @@ Proof.
   assert (S8 : (∀ x, φ x ∧ ψ x) → ((∀ y, φ y) ∧ ∀ z, ψ z)).
   {
     pose proof (Comp3_43 (∀ x, φ x ∧ ψ x) (∀ y, φ y) (∀ z, ψ z)) as Comp3_43.
-    assert (C1 : ((∀ x, φ x ∧ ψ x) → ∀ y, φ y)
-      ∧ ((∀ x, φ x ∧ ψ x) → ∀ y, ψ y)).
-    { clear S1 S2 S3 S5 S6 Comp3_43. now Conj_as S4 S7 C1. }
+    Conj_as S4 S7 C1.
     now MP Comp3_43 C1.
   }
   assert (S9 : ∀ y, (∀ x, φ x) ∧ (∀ x, ψ x) → (φ y ∧ ψ y)).
@@ -188,12 +184,7 @@ Proof.
   }
   assert (S11 : (∀ x, φ x ∧ ψ x) ↔ (∀ x, φ x) ∧ (∀ x, ψ x)).
   {
-    assert (C1 : ((∀ x, φ x ∧ ψ x) → ((∀ y, φ y) ∧ ∀ z, ψ z))
-      ∧ ((∀ x, φ x) ∧ (∀ x, ψ x) → ∀ y, (φ y ∧ ψ y))).
-    {
-      clear S1 S2 S3 S4 S5 S6 S7 S9.
-      now Conj_as S8 S10 C1.
-    }
+    Conj_as S8 S10 C1.
     now Equiv C1.
   }
   exact S11.
@@ -238,9 +229,7 @@ Proof.
     pose proof (Transp2_17 (∃ x, φ x) P) as Transp2_17.
     rewrite -> n10_01 in Transp2_17 at 1.
     rewrite <- (n4_13 (∀ x, ¬ φ x)) in Transp2_17.
-    assert (C1 : (((∃ x, φ x) → P) → (¬ P → ∀ x, ¬ φ x))
-      ∧ ((¬ P → ∀ x, ¬ φ x) → ((∃ x, φ x) → P))).
-    { now Conj_as Transp2_16 Transp2_17 C1. }
+    Conj_as Transp2_16 Transp2_17 C1.
     Equiv C1.
     exact C1.
   }
@@ -294,24 +283,16 @@ Proof.
     Syll_as S8 S8_1 S8_2.
     pose proof (n10_21 (fun x => ¬ φ x) (¬ P)) as n10_21.
     destruct n10_21 as [_ n10_21].
-    clear S1 S2 S3 S4 S5 S6 S7 n10_11 S8 S8_1.
     now Syll_as S8_2 n10_21 S9.
   }
   assert (S10 : (∀ x, (φ x → P)) → (∃ x, φ x) → P).
   {
     destruct S2 as [_ S2].
-    clear S1 S3 S4 S5 S6 S7 S8.
     now Syll_as S9 S2 S10.
   }
   assert (S11 : (∀ x, φ x → P) ↔ ((∃ x, φ x) → P)).
   {
-    assert (C1 : ((∀ x, (φ x → P)) → (∃ x, φ x) → P)
-      ∧ (((∃ x, φ x) → P) → ∀ x, (φ x → P))).
-    {
-      clear S1 S2 S3 S4 S5 S7 S8 S9.
-      move S10 after S6.
-      now Conj_as S10 S6 C1.
-    }
+    Conj_as S10 S6 C1.
     now Equiv C1.
   }
   exact S11.
@@ -388,7 +369,7 @@ Proof.
   {
     (* n10_21 is unused *)
     pose proof (n10_11 Y (fun y => ¬¬ φ y)) as n10_11.
-    now Syll_as S2 n10_21 S3.
+    now Syll_as S2 n10_11 S3.
   }
   assert (S4 : (¬ (∀ y, ¬¬ φ y)) → ¬ (∀ x, φ x)).
   {
@@ -421,13 +402,7 @@ Proof.
   { now rewrite <- n10_01 in S9. }
   assert (S11 : (¬ (∀ x, φ x)) ↔ ∃ x, ¬ φ x).
   {
-    assert (C1 : ((¬ (∀ x, φ x)) → ∃ x, ¬ φ x)
-      ∧ ((∃ x, ¬ φ x) → ¬ (∀ x, φ x))).
-    {
-      clear S1 S2 S3 S4 S6 S7 S8 S9.
-      move S10 after S5.
-      now Conj_as S10 S5 C1.
-    }
+    Conj_as S10 S5 C1.
     now Equiv C1.
   }
   exact S11.
@@ -452,10 +427,9 @@ Proof.
   { exact (n10_14 (fun z => φ z → ψ z) φ Y). }
   assert (S2 : ((∀ z, φ z → ψ z) ∧ (∀ z, φ z)) → ψ Y).
   {
-    pose proof (Ass3_35 (φ Y) (ψ Y)) as Ass3_35.
     pose proof (n3_22 (φ Y → ψ Y) (φ Y)) as n3_22.
+    pose proof (Ass3_35 (φ Y) (ψ Y)) as Ass3_35.
     Syll_as n3_22 Ass3_35 S2.
-    clear n3_22.
     now Syll_as S1 S2 S2_1.
   }
   assert (S3 : ∀ y, ((∀ z, φ z → ψ z) ∧ (∀ z, φ z)) → ψ y).
@@ -508,8 +482,7 @@ Proof.
     intro Hp.
     pose proof (n10_27 φ ψ) as n10_27.
     pose proof (S1 Hp) as S1.
-    clear n10_22l.
-    now MP n10_27 S11.
+    now MP n10_27 S1.
   }
   assert (S3 : (∀ z, φ z ↔ ψ z) → (∀ z, ψ z → φ z)).
   {
@@ -522,14 +495,11 @@ Proof.
     intro Hp.
     pose proof (n10_27 ψ φ) as n10_27.
     pose proof (S3 Hp) as S3.
-    clear S2 Hp.
     now MP n10_27 S3.
   }
   assert (S5 : (∀ z, φ z ↔ ψ z) → ((∀ z, φ z) ↔ (∀ z, ψ z))).
   {
-    assert (C1 : ((∀ z, φ z ↔ ψ z) → ((∀ z, φ z) → (∀ z, ψ z)))
-      ∧ ((∀ z, φ z ↔ ψ z) → ((∀ z, ψ z) → (∀ z, φ z)))).
-    { clear n10_22l S1 S3. now Conj_as S2 S4 C1. }
+    Conj_as S2 S4 C1.
     pose proof (Comp3_43 (∀ z, φ z ↔ ψ z)
       ((∀ z, φ z) → (∀ z, ψ z))
       ((∀ z, ψ z) → (∀ z, φ z))
@@ -611,19 +581,11 @@ Proof.
     ((∃ x, φ x) → (∃ x, ψ x))
     ((∃ x, ψ x) → (∃ x, φ x))
   ) as Comp3_43.
-  assert (C1 : ((∀ x, φ x ↔ ψ x) → (∃ x, φ x) → (∃ x, ψ x))
-    ∧ ((∀ x, φ x ↔ ψ x) → (∃ x, ψ x) → (∃ x, φ x))).
-  {
-    clear Equiv4_01a n10_22l Comp3_43.
-    now Conj_as Sa Sb C1.
-  }
+  Conj_as Sa Sb C1.
   MP Comp3_43 C1.
-  assert (Sc : (∀ x, φ x → ψ x) ∧ (∀ x, ψ x → φ x)
-    → ((∃ x, φ x) → ∃ x, ψ x) ∧ ((∃ x, ψ x) → ∃ x, φ x)).
-  { clear n10_22l. now Syll_as n10_22r Comp3_43 Sc. }
+  Syll_as n10_22r Comp3_43 Sc.
   setoid_rewrite <- Equiv4_01a in Sc.
-  assert (Sd : (∀ x, φ x ↔ ψ x) → (∃ x, φ x) ↔ ∃ x, ψ x).
-  { clear n10_22r. now Syll_as n10_22r Sc Sd. }
+  Syll_as n10_22l Sc Sd.
   exact Sd.
 Qed.
 
@@ -648,7 +610,7 @@ Proof.
   {
     pose proof (n10_11 X (fun x => ((φ x → ψ x) ∧ (φ x → χ x)) 
       ↔ (φ x → (ψ x ∧ χ x)))) as n10_11.
-    now MP n10_11 S3.
+    now MP n10_11 S2.
   }
   assert (S4 : (∀ x, (φ x → ψ x) ∧ (φ x → χ x))
     ↔ (∀ x, φ x → (ψ x ∧ χ x))).
@@ -661,12 +623,7 @@ Proof.
   }
   assert (S5 : ((∀ x, φ x → ψ x) ∧ (∀ x, φ x → χ x)) ↔ (∀ x, φ x → (ψ x ∧ χ x))).
   {
-    assert (C1 : 
-      (((∀ x, φ x → ψ x) ∧ (∀ x, φ x → χ x)) 
-        ↔ (∀ x, (φ x → ψ x) ∧ (φ x → χ x)))
-      ∧ ((∀ x, (φ x → ψ x) ∧ (φ x → χ x))
-         ↔ (∀ x, φ x → (ψ x ∧ χ x)))).
-    { clear S2 S3. now Conj_as S1 S4 C1. }
+    Conj_as S1 S4 C1.
     pose proof (n4_22
       ((∀ x, φ x → ψ x) ∧ (∀ x, φ x → χ x))
       (∀ x, (φ x → ψ x) ∧ (φ x → χ x))
@@ -701,27 +658,27 @@ Proof.
     intro Hp.
     pose proof (S1 Hp) as S1.
     (* Original proof here has abbreviated a lot of proofs being explained separately *)
-    assert (Sy1 : (φ X → ψ X) ∧ (ψ X → χ X) → (φ X → χ X)).
+    assert (S1_1 : (φ X → ψ X) ∧ (ψ X → χ X) → (φ X → χ X)).
     {
       pose proof (Syll2_06 (φ X) (ψ X) (χ X)) as Syll2_06.
       pose proof (Imp3_31 (φ X → ψ X) (ψ X → χ X) 
         (φ X → χ X)) as Imp3_31.
       now MP Imp3_31 Syll2_06.
     }
-    assert (Sy2 : ∀ x, (φ x → ψ x) ∧ (ψ x → χ x) → (φ x → χ x)).
+    assert (S1_2 : ∀ x, (φ x → ψ x) ∧ (ψ x → χ x) → (φ x → χ x)).
     {
       pose proof (n10_11 X (fun x => (φ x → ψ x) 
         ∧ (ψ x → χ x) → (φ x → χ x))) as n10_11.
-      now MP n10_11 Sy1.
+      now MP n10_11 S1_1.
     }
-    assert (Sy3 : (∀ x, (φ x → ψ x) ∧ (ψ x → χ x)) 
+    assert (S1_3 : (∀ x, (φ x → ψ x) ∧ (ψ x → χ x)) 
       → (∀ y, φ y → χ y)).
     {
       pose proof (n10_27 (fun x => (φ x → ψ x) ∧ (ψ x → χ x))
         (fun x => (φ x → χ x))) as n10_27.
-      now MP n10_27 Sy2.
+      now MP n10_27 S1_2.
     }
-    now MP Sy3 S1.
+    now MP S1_3 S1.
   }
   exact S2.
 Qed.
@@ -741,7 +698,7 @@ Proof.
     pose proof (n10_11 X
       (fun x => ((φ x ↔ ψ x) ∧ (ψ x ↔ χ x)) 
         → (φ x ↔ χ x))) as n10_11.
-    MP n10_11 S1.
+    MP n10_11 n4_22.
     pose proof (n10_27
       (fun x => (φ x ↔ ψ x) ∧ (ψ x ↔ χ x))
       (fun x => (φ x ↔ χ x))) as n10_27.
@@ -823,12 +780,7 @@ Proof.
   {
     pose proof (n4_3 ((φ x) -[1 x ]> (ψ x)) ((ψ x) -[1 x ]> (φ x))) 
       as n4_3.
-    assert (C1 : ((φ x <[1- x -]> ψ x) ↔
-      ((φ x -[1 x ]> ψ x) ∧ (ψ x -[1 x ]> φ x)))
-      ∧
-      ((φ x -[1 x ]> ψ x) ∧ (ψ x -[1 x ]> φ x) ↔
-      (ψ x -[1 x ]> φ x) ∧ (φ x -[1 x ]> ψ x))).
-    { now Conj_as S1 n4_3 C1. }
+    Conj_as S1 n4_3 C1.
     pose proof (n4_22
       ((φ x) <[1- x -]> (ψ x))
       (((φ x) -[1 x ]> (ψ x)) ∧ ((ψ x) -[1 x ]> (φ x)))
@@ -843,12 +795,7 @@ Proof.
       (fun x => (ψ x → φ x))
       (fun x => (φ x → ψ x))) as n10_22. 
     symmetry in n10_22.
-    assert (C1 : ((φ x <[1- x -]> ψ x) 
-        ↔ ((ψ x -[1 x ]> φ x) ∧ (φ x -[1 x ]> ψ x)))
-      ∧
-      (((ψ x -[1 x ]> φ x) ∧ (φ x -[1 x ]> ψ x)) 
-        ↔ ∀ x, (ψ x → φ x) ∧ (φ x → ψ x))).
-    { now Conj_as S2 n10_22 C1. }
+    Conj_as S2 n10_22 C1.
     pose proof (n4_22
       (φ x <[1- x -]> ψ x)
       ((ψ x -[1 x ]> φ x) ∧ (φ x -[1 x ]> ψ x))
@@ -940,13 +887,7 @@ Proof.
   assert (S5 : (∀ x, φ x ∧ P) → (∀ y, φ y) ∧ P).
   {
     (* Original text here seems unsatisfying in a sense of rigor *)
-    assert (C1 : ((∀ x, φ x ∧ P) → ∀ y, φ y)
-      ∧ ((∀ x, φ x ∧ P) → P)).
-    {
-      clear S1 S3.
-      move S2 after S4.
-      now Conj_as S4 S2 C1.
-    }
+    Conj_as S4 S2 C1.
     now rewrite -> (n4_76 (∀ x, φ x ∧ P) (∀ y, φ y) P) in C1.
   }
   assert (S6 : (∀ y, φ y) → φ X).
@@ -968,8 +909,6 @@ Proof.
   }
   assert (S9 : (∀ x, φ x ∧ P) ↔ ((∀ x, φ x) ∧ P)).
   {
-    clear S1 S2 S3 S4 S6 S7.
-    move S5 after S8.
     Conj_as S8 S5 S9.
     now Equiv S9.
   }
@@ -1040,28 +979,24 @@ Proof.
   {
     (* n10_21 ignored - seems completely unnecessary *)
     pose proof (n10_11 X (fun x => φ x → (P ∧ φ x))) as n10_11.
-    now Syll_as n10_11 S7 S8.
+    simpl in n10_11.
+    now Syll_as S7 n10_11 S8.
   }
   assert (S9 : P → ((∃ x, φ x) → (∃ x, P ∧ φ x))).
   {
     pose proof (n10_28 φ (fun x => P ∧ φ x)) as n10_28.
-    now Syll_as n10_28 S8 S9.
+    now Syll_as S8 n10_28 S9.
   }
   assert (S10 : (∃ x, P ∧ φ x) ↔ P ∧ (∃ x, φ x)).
   {
-    clear S1 S2 S4 S5 S7 S8.
     pose proof (Imp3_31 P ((∃ x, φ x)) (∃ x, P ∧ φ x))
       as Imp3_31.
     MP Imp3_31 S9.
-    assert (C1 : ((∃ x, P ∧ φ x) → P) 
-      ∧ ((∃ x, P ∧ φ x) → ∃ x, φ x)).
-    { now Conj_as S3 S6 C1. }
+    Conj_as S3 S6 C1.
     pose proof (Comp3_43 (∃ x, P ∧ φ x) P (∃ x, φ x))
       as Comp3_43.
     MP Comp3_43 C1.
-    assert (C2 : ((∃ x, P ∧ φ x) → P ∧ ∃ x, φ x)
-      ∧ (P ∧ (∃ x, φ x) → ∃ x, P ∧ φ x)).
-    { now Conj_as Comp3_43 Imp3_31 C2. }
+    Conj_as Comp3_43 Imp3_31 C2.
     now Equiv C2.
   }
   exact S10.
@@ -1177,10 +1112,7 @@ Proof.
     pose proof (Simp3_26 (ψ x -[1 x ]> θ x) (θ x -[1 x ]> ψ x))
       as Simp3_26b.
     Syll_as n10_22bl Simp3_26b n10_22bl_1.
-    clear n10_22al n10_22bl Simp3_26a Simp3_26b.
-    assert (C1 : ((φ x <[1- x -]> χ x) → (φ x -[1 x ]> χ x))
-      ∧ ((ψ x <[1- x -]> θ x) → (ψ x -[1 x ]> θ x))).
-    { now Conj_as n10_22al_1 n10_22bl_1 C1. }
+    Conj_as n10_22al_1 n10_22bl_1 C1.
     pose proof (n3_47 
       (φ x <[1- x -]> χ x) (ψ x <[1- x -]> θ x)
       (φ x -[1 x ]> χ x) (ψ x -[1 x ]> θ x))
@@ -1191,7 +1123,7 @@ Proof.
     → (φ x ∧ ψ x) -[1 x ]> (χ x ∧ θ x)).
   {
     pose proof (n10_39 φ ψ χ θ) as n10_39.
-    now Syll_as n10_39 S1 S2.
+    now Syll_as S1 n10_39 S2.
   }
   assert (S3 : ((φ x <[1- x -]> χ x) ∧ ((ψ x <[1- x -]> θ x)))
     → (χ x ∧ θ x) -[1 x ]> (φ x ∧ ψ x)).
@@ -1202,10 +1134,7 @@ Proof.
     pose proof (Simp3_27 (ψ x -[1 x ]> θ x) (θ x -[1 x ]> ψ x))
       as Simp3_27b.
     Syll_as n10_22bl Simp3_27b n10_22bl_1.
-    clear n10_22al n10_22bl Simp3_27a Simp3_27b.
-    assert (C1 : ((φ x <[1- x -]> χ x) → (χ x -[1 x ]> φ x))
-      ∧ ((ψ x <[1- x -]> θ x) → (θ x -[1 x ]> ψ x))).
-    { now Conj_as n10_22al_1 n10_22bl_1 C1. }
+    Conj_as n10_22al_1 n10_22bl_1 C1.
     pose proof (n3_47
       (φ x <[1- x -]> χ x) (ψ x <[1- x -]> θ x)
       (χ x -[1 x ]> φ x) (θ x -[1 x ]> ψ x)
@@ -1218,13 +1147,7 @@ Proof.
     → (((φ x ∧ ψ x) -[1 x ]> (χ x ∧ θ x))
         ∧ ((χ x ∧ θ x) -[1 x ]> (φ x ∧ ψ x)))).
   {
-    assert (C1 : 
-      ((φ x <[1- x -]> χ x) ∧ (ψ x <[1- x -]> θ x)
-        → ((φ x ∧ ψ x) -[1 x ]> χ x ∧ θ x))
-      ∧
-      ((φ x <[1- x -]> χ x) ∧ (ψ x <[1- x -]> θ x)
-        → ((χ x ∧ θ x) -[1 x ]> φ x ∧ ψ x))).
-    { now Conj_as S1 S3 C1. }
+    Conj_as S2 S3 C1.
     pose proof (Comp3_43
       ((φ x <[1- x -]> χ x) ∧ ((ψ x <[1- x -]> θ x)))
       ((φ x ∧ ψ x) -[1 x ]> (χ x ∧ θ x))
@@ -1261,7 +1184,7 @@ Proof.
   assert (S4 : (∀ x, ψ x) → (φ Y ∨ ψ Y)).
   {
     pose proof (Add1_3 (φ Y) (ψ Y)) as Add1_3.
-    now Syll_as S2 Add1_3 S3.
+    now Syll_as S3 Add1_3 S4.
   }
   assert (S5 : ((∀ x, φ x) → (φ Y ∨ ψ Y))
     ∧ ((∀ x, ψ x) → (φ Y ∨ ψ Y))).
@@ -1310,7 +1233,7 @@ Proof.
     → ((φ X ∨ ψ X) ↔ (χ X ∨ θ X))).
   {
     pose proof (n4_39 (φ X) (ψ X) (χ X) (θ X)) as n4_39.
-    now Syll_as n4_39 S1 S2.
+    now Syll_as S1 n4_39 S2.
   }
   assert (S3 : ((φ x <[1- x -]> χ x) ∧ ((ψ x <[1- x -]> θ x)))
     → (φ x ∨ ψ x) <[1- x -]> (χ x ∨ θ x)).
@@ -1340,7 +1263,7 @@ Proof.
   MP n10_11 Transp4_11.
   pose proof (n10_271 (fun x => φ x ↔ ψ x) 
     (fun x => ¬ φ x ↔ ¬ ψ x)) as n10_271.
-  now MP n10_11 n10_271.
+  now MP n10_271 n10_11.
 Qed.
 
 Theorem n10_413 (φ ψ χ θ : Prop → Prop) :
@@ -1384,13 +1307,7 @@ Proof.
     → (φ x ↔ ψ x) <[1- x -]> (χ x ↔ θ x)).
   {
     pose proof (n10_413 φ ψ χ θ) as n10_413.
-    assert (C1 :
-      ((φ x <[1- x -]> χ x) ∧ (ψ x <[1- x -]> θ x) →
-        (ψ x → φ x) <[1- x -]> (θ x → χ x))
-      ∧
-      ((φ x <[1- x -]> χ x) ∧ (ψ x <[1- x -]> θ x) →
-        (φ x → ψ x) <[1- x -]> (χ x → θ x))).
-    { now Conj_as S1 n10_413 C1. }
+    Conj_as S1 n10_413 C1.
     pose proof (n10_4
       (fun x => ψ x → φ x)
       (fun x => φ x → ψ x)
@@ -1403,7 +1320,6 @@ Proof.
       ((φ x → ψ x) <[1- x -]> (χ x → θ x))
       ) as n4_76.
     rewrite -> n4_76 in C1.
-    clear S1 n10_413 n4_76.
     Syll_as C1 n10_4 S1_1.
     setoid_rewrite <- Equiv4_01a in S1_1.
     (* Change the orders in conclusion *)
@@ -1468,7 +1384,7 @@ Proof.
   {
     pose proof (Simp3_26 (φ X) (ψ X)) as Simp3_26.
     pose proof (n10_11 X (fun x => φ x ∧ ψ x → φ x)) as n10_11.
-    now MP Simp3_26 n10_11.
+    now MP n10_11 Simp3_26.
   }
   assert (S2 : (∃ x, (φ x ∧ ψ x)) → (∃ x, φ x)).
   {
@@ -1477,9 +1393,9 @@ Proof.
   }
   assert (S3 : ∀ x, (φ x ∧ ψ x) → ψ x).
   {
-    pose proof (Simp3_27 (φ X) (ψ X)) as Simp3_26.
+    pose proof (Simp3_27 (φ X) (ψ X)) as Simp3_27.
     pose proof (n10_11 X (fun x => φ x ∧ ψ x → ψ x)) as n10_11.
-    now MP Simp3_27 n10_11.
+    now MP n10_11 Simp3_27.
   }
   assert (S4 : (∃ x, (φ x ∧ ψ x)) → (∃ x, ψ x)).
   {
@@ -1488,12 +1404,10 @@ Proof.
   }
   assert (S5 : (∃ x, φ x ∧ ψ x) → ((∃ x, φ x) ∧ (∃ x, ψ x))).
   {
-    assert (C1 : ((∃ x, φ x ∧ ψ x) → ∃ x, φ x)
-      ∧ ((∃ x, φ x ∧ ψ x) → ∃ x, ψ x)).
-    { now Conj_as S2 S4 C1. }
+    Conj_as S2 S4 C1.
     pose proof (Comp3_43 (∃ x, φ x ∧ ψ x) (∃ x, φ x)
       (∃ x, ψ x)) as Comp3_43.
-    now MP C1 Comp3_43.
+    now MP Comp3_43 C1.
   }
   exact S5.
 Qed.
@@ -1540,7 +1454,7 @@ Proof.
     pose proof (n2_21 (φ X) (ψ X)) as n2_21.
     pose proof (n10_11 X (fun x => (¬ φ x) → (φ x → ψ x))) 
       as n10_11.
-    now MP n2_21 n10_11.
+    now MP n10_11 n2_21.
   }
   assert (S2 : (∀ x, ¬ φ x) → (∀ x, φ x → ψ x)).
   {
@@ -1614,7 +1528,7 @@ Proof.
     MP n10_11 S1.
     pose proof (n10_27 (fun x => φ x → ψ x)
       (fun x => (φ x ∧ ψ x) ↔ φ x)) as n10_27.
-    now MP n10_11 n10_27.
+    now MP n10_27 n10_11.
   }
   assert (S3 : (φ x -[1 x ]> ψ x) 
     → ((∃ x, φ x ∧ ψ x) ↔ (∃ x, φ x))).

--- a/pm/ch10.v
+++ b/pm/ch10.v
@@ -349,7 +349,7 @@ Theorem n10_252_alt (φ : Prop → Prop) : ¬ (∃ x, φ x) ↔ (∀ x, ¬ φ x)
 Proof.
   pose proof (n4_13 (∀ x, ¬ φ x)) as n4_13.
   rewrite <- n10_01 in n4_13 at 1.
-  now symmetry in n4_13.
+  now rewrite -> n4_21 in n4_13.
 Qed.
 
 Theorem n10_253_alt (φ : Prop → Prop) : (¬ (∀ x, φ x)) ↔ (∃ x, ¬ φ x).
@@ -600,7 +600,7 @@ Proof.
   {
     pose proof (n10_22 (fun x => φ x → ψ x) 
       (fun x => φ x → χ x)) as n10_22.
-    now symmetry in n10_22.
+    now rewrite -> n4_21 in n10_22.
   }
   assert (S2 : ((φ X → ψ X) ∧ (φ X → χ X)) 
     ↔ (φ X → (ψ X ∧ χ X))).
@@ -794,7 +794,7 @@ Proof.
     pose proof (n10_22 
       (fun x => (ψ x → φ x))
       (fun x => (φ x → ψ x))) as n10_22. 
-    symmetry in n10_22.
+    rewrite -> n4_21 in n10_22.
     Conj_as S2 n10_22 C1.
     pose proof (n4_22
       (φ x <[1- x -]> ψ x)
@@ -1011,7 +1011,7 @@ Proof.
   assert (S1 : (φ X ∨ P) ↔ ((¬ φ X) → P)).
   {
     pose proof (n4_64 (φ X) P) as n4_64.
-    now symmetry in n4_64.
+    now rewrite -> n4_21 in n4_64.
   }
   assert (S2 : ∀ x, (φ x ∨ P) ↔ ((¬ φ x) → P)).
   {
@@ -1065,7 +1065,7 @@ Proof.
   {
     pose proof (n10_22 (fun x => φ x → χ x) (fun x => ψ x → θ x))
       as n10_22.
-    symmetry in n10_22.
+      rewrite -> n4_21 in n10_22.
     now destruct n10_22.
   }
   assert (S2 : ((φ x -[1 x ]> χ x) ∧ (ψ x -[1 x ]> θ x))
@@ -1337,7 +1337,7 @@ Proof.
   {
     pose proof (n10_22 
       (fun x => ¬ φ x) (fun x => ¬ ψ x)) as n10_22.
-    now symmetry in n10_22.
+    now rewrite -> n4_21 in n10_22.
   }
   assert (S2 : (¬ ((∀ x, ¬ φ x) ∧ (∀ x, ¬ ψ x)))
     ↔ (¬ (∀ x, (¬ φ x) ∧ (¬ ψ x)))).
@@ -1433,14 +1433,14 @@ Proof.
   assert (S1 : (∃ x, φ x) → (P ↔ ((∃ x, φ x) → P))).
   {
     pose proof (n5_5 (∃ x, φ x) P) as n5_5.
-    now symmetry in n5_5.
+    now rewrite -> n4_21 in n5_5.
   }
   assert (S2 : (∃ x, φ x) → (P ↔ (∀ x, φ x → P))).
   {
     pose proof n10_23 as n10_23.
     now setoid_rewrite <- n10_23 in S1 at 2.
   }
-  now symmetry in S2.
+  now rewrite -> n4_21 in S2.
 Qed.
 
 Theorem n10_53 (φ ψ : Prop → Prop) :

--- a/pm/ch11.v
+++ b/pm/ch11.v
@@ -398,7 +398,7 @@ Proof.
     ↔ (∀ x, P → ∀ y, φ x y)).
   {
     pose proof (n10_21 (fun x => ∀ y, φ x y) P) as n10_21.
-    now symmetry in n10_21. 
+    now rewrite -> n4_21 in n10_21. 
   }
   assert (S2 : (P → (∀ x y, φ x y)) ↔ (∀ x y, P → φ x y)).
   {
@@ -417,7 +417,7 @@ Proof.
   {
     pose proof (n10_22 (fun x => ∀ y, φ x y)
       (fun x => ∀ y, ψ x y)) as n10_22.
-    now symmetry in n10_22.
+    now rewrite -> n4_21 in n10_22.
   }
   assert (S2 : ((∀ x y, φ x y) ∧ (∀ x y, ψ x y))
     ↔
@@ -850,7 +850,7 @@ Proof.
   {
     pose proof (n10_253_alt (fun x => ∀ y, φ x y))
        as n10_253_alt.
-    now symmetry in n10_253_alt.
+    now rewrite -> n4_21 in n10_253_alt.
   }
   assert (S2 : (∃ x, ¬ ∀ y, φ x y) ↔ ¬ (∀ x y, φ x y)).
   {
@@ -1040,12 +1040,12 @@ Proof.
   assert (S1 : ((∀ x, φ x) ∧ (∀ y, ψ y)) ↔ (∀ x, φ x ∧ ∀ y, ψ y)).
   { 
     pose proof (n10_33 φ (∀ y, ψ y)) as n10_33.
-    now symmetry in n10_33.
+    now rewrite -> n4_21 in n10_33.
   }
   assert (S2 : (φ X ∧ (∀ y, ψ y)) ↔ (∀ y, φ X ∧ ψ y)).
   {
     pose proof (n10_33 ψ (φ X)) as n10_33.
-    symmetry in n10_33.
+    rewrite -> n4_21 in n10_33.
     rewrite <- n4_3 in n10_33.
     now setoid_rewrite <- n4_3 in n10_33 at 3.
   }
@@ -1292,11 +1292,10 @@ Proof.
     ↔ ((∃ x y, φ x y) ∨ (∃ x y, φ y x))).
   { 
     pose proof (n11_41 φ) as n11_41.
-    now symmetry in n11_41.
+    now setoid_rewrite -> n4_21 in n11_41.
   }
   assert (S2 : (∃ x y, φ x y ∨ φ y x) 
     ↔ ((∃ x y, φ x y) ∨ (∃ y x, φ y x))).
-  (* Idk why I have to use `setoid_rewrite` on this *)
   { now setoid_rewrite -> n11_23 in S1 at 3. }
   assert (S3 : (∃ x y, φ x y ∨ φ y x) 
     ↔ (∃ x y, φ x y)).

--- a/pm/ch11.v
+++ b/pm/ch11.v
@@ -75,7 +75,7 @@ Proof.
   assert (S2 : (∀ x y, φ x y) → φ Z W).
   { 
     pose proof (n10_1 (fun y => φ Z y) W) as n10_1.
-    now Syll S1 n10_1 S2.
+    now Syll_as S1 n10_1 S2.
   }
   exact S2.
 Qed.
@@ -106,7 +106,7 @@ Proof.
   assert (S3 : (∀ x y, P ∨ φ x y) → (P ∨ ∀ x y, φ x y)).
   {
     pose proof (n10_12 (fun x => ∀ y, φ x y) P) as n10_12.
-    now Syll n10_12 S2 S3.
+    now Syll_as n10_12 S2 S3.
   }
   exact S3.
 Qed.
@@ -129,7 +129,7 @@ Proof.
   assert (S2 : ((∀ x y, φ x y) ∧ (∀ x y, ψ x y)) → (φ Z W ∧ ψ Z W)).
   {
     pose proof (n10_14 (fun y => φ Z y) (fun y => ψ Z y) W) as n10_14.
-    now Syll S1 n10_14 S2.
+    now Syll_as S1 n10_14 S2.
   }
   exact S2.
 Qed.
@@ -179,7 +179,7 @@ Proof.
     now MP n11_12 S4_2.
   }
   assert (S5 : (∀ x y, φ x y) ↔ (∀ y x, φ x y)).
-  { clear S1 S2. Conj S3 S4 C1. now Equiv C1. }
+  { clear S1 S2. Conj_as S3 S4 C1. now Equiv C1. }
   exact S5.
 Qed.  
 
@@ -387,7 +387,7 @@ Proof.
   {
     (* n11_04 ignored. It should be applied on the `∃ x, ∃ y, ∃ z`
     side of S1 and S3. *)
-    now Conj S1 S3 S4.
+    now Conj_as S1 S3 S4.
   }
   exact S4.
 Qed.
@@ -448,7 +448,7 @@ Proof.
       → (∀ y, φ x y) → ∀ y, ψ x y)) as n10_11.
   MP n10_11 n10_27a.
   MP n10_27b n10_11.
-  now Syll n10_27b n10_27c Sy1.
+  now Syll_as n10_27b n10_27c Sy1.
 Qed.
 
 Theorem n11_33 (φ ψ : Prop → Prop → Prop) :
@@ -467,7 +467,7 @@ Proof.
   pose proof (n10_27 (fun x => (∀ y, φ x y ↔ ψ x y))
     (fun x => (∀ y, φ x y) ↔ ∀ y, ψ x y)) as n10_27.
   MP n10_27 n10_11.
-  now Syll n10_27 n10_27b S1.
+  now Syll_as n10_27 n10_27b S1.
 Qed.
 
 Theorem n11_34 (φ ψ : Prop → Prop → Prop) :
@@ -486,7 +486,7 @@ Proof.
   MP n10_27a n10_11.
   pose proof (n10_28 (fun x => ∃ y, φ x y)
     (fun x => ∃ y, ψ x y)) as n10_28b.
-  now Syll n10_27 n10_28b S1.
+  now Syll_as n10_27 n10_28b S1.
 Qed.
 
 Theorem n11_341 (φ ψ : Prop → Prop → Prop) :
@@ -505,7 +505,7 @@ Proof.
   MP n10_271 n10_11.
   pose proof (n10_281 (fun x => (∃ y, φ x y))
     (fun x => ∃ y, ψ x y)) as n10_281b.
-  now Syll n10_271 n10_281b S1.
+  now Syll_as n10_271 n10_281b S1.
 Qed.
 
 Theorem n11_35 (P : Prop) (φ : Prop → Prop → Prop) :
@@ -568,7 +568,7 @@ Proof.
   }
   assert (S4 : ((∀ x y, φ x y → ψ x y) ∧ (∀ x y, ψ x y → χ x y))
     → (∀ x y, φ x y → χ x y)).
-  { now Syll S1 S3 S4. }
+  { now Syll_as S1 S3 S4. }
   exact S4.
 Qed.
 
@@ -626,7 +626,7 @@ Proof.
   MP n11_32a n11_11.
   pose proof (n11_32 (fun x y => φ x y ∧ χ x y) 
     (fun x y => ψ x y ∧ θ x y)) as n11_32b.
-  Syll n11_32a n11_32b S1.
+  Syll_as n11_32a n11_32b S1.
   now rewrite <- n11_31 in S1.
 Qed.
 
@@ -681,7 +681,7 @@ Proof.
     pose proof (n11_32 (fun x y => (φ x y ↔ ψ x y) ∧ (χ x y ↔ θ x y))
       (fun x y => φ x y ∧ χ x y ↔ ψ x y ∧ θ x y)) as n11_32.
     MP n11_32 n11_11.
-    now Syll S1 n11_32 S2.
+    now Syll_as S1 n11_32 S2.
   }
   exact S2.
 Qed.
@@ -744,7 +744,7 @@ Proof.
   MP n10_28 n10_11.
   pose proof (n10_5 (fun x => (∃ y, φ x y))
     (fun x => ∃ y, ψ x y)) as n10_5b.
-  now Syll n10_28 n10_5b S1.
+  now Syll_as n10_28 n10_5b S1.
 Qed.
 
 Theorem n11_421 (φ ψ : Prop → Prop → Prop) :
@@ -880,7 +880,7 @@ Proof.
     clear S1 S3 S4.
     (* ??????? *)
     rewrite -> S2 in S5.
-    now Conj S2 S5 S6.
+    now Conj_as S2 S5 S6.
   }
   exact S6.
 Qed.
@@ -1109,7 +1109,7 @@ Proof.
       (fun x y => φ x ∧ φ y → ψ x ∧ ψ y)) as n11_32.
     MP n11_32 n11_11.
     destruct S1 as [S1l _].
-    now Syll S1 n11_32 S2.
+    now Syll_as S1 n11_32 S2.
   }
   assert (S3 : (∀ x y, (φ x ∧ φ y) → (ψ x ∧ ψ y)) 
     → ((φ X ∧ φ Y) → (ψ X ∧ ψ Y))).
@@ -1145,7 +1145,7 @@ Proof.
     ((φ x ∧ φ y) -[ x y ]> (ψ x ∧ ψ y))).
   {
     clear S1 S3 S4.
-    Conj S2 S5 S6.
+    Conj_as S2 S5 S6.
     now Equiv S6.
   }
   exact S6.
@@ -1221,7 +1221,7 @@ Proof.
     now MP n10_27 n10_11.
   }
   assert (S4 : (∃ y, (φ x -[ x ]> ψ x y)) → (φ x -[ x ]> ∃ y, ψ x y)).
-  { clear S2. now Syll S1 S3 S4. }
+  { clear S2. now Syll_as S1 S3 S4. }
   exact S4.
 Qed.
 
@@ -1331,13 +1331,13 @@ Proof.
       ((φ x -[ x ]> ψ x) → (φ Z → ψ Z))
       ∧
       ((χ x -[ x ]> θ x) → (χ W →θ W))).
-    { now Conj n10_1a n10_1b C1. }
+    { now Conj_as n10_1a n10_1b C1. }
     pose proof (n3_47
       (φ z -[ z ]> ψ z) (χ w -[ w ]> θ w)
       (φ Z → ψ Z) (χ W → θ W)) as n3_47a.
     MP n3_47a C1.
     pose proof (n3_47 (φ Z) (χ W) (ψ Z) (θ W)) as n3_47b.
-    now Syll n3_47a n3_47b S1.
+    now Syll_as n3_47a n3_47b S1.
   }
   assert (S2 : ((φ z -[ z ]> ψ z) ∧ (χ w -[ w ]> θ w))
     → (∀ z w, (φ z ∧ χ w) → ψ z ∧ θ w)).
@@ -1347,7 +1347,7 @@ Proof.
     (* n11_3 ignored *)
     pose proof (n11_11 Z W (fun z w => (φ z ∧ χ w) 
       → ψ z ∧ θ w)) as n11_11.
-    now Syll S1 n11_11 S2.
+    now Syll_as S1 n11_11 S2.
   }
   assert (S3 : (∀ z w, (φ z ∧ χ w) → ψ z ∧ θ w)
     → ((φ Z ∧ χ w) -[ w ]> (ψ Z ∧ θ w))).
@@ -1360,7 +1360,7 @@ Proof.
   {
     pose proof (n10_28 (fun w => φ Z ∧ χ w)
       (fun w => ψ Z ∧ θ w)) as n10_28.
-    now Syll S3 n10_28 S4.
+    now Syll_as S3 n10_28 S4.
   }
   assert (S5 : (∀ z w, (φ z ∧ χ w) → ψ z ∧ θ w)
     → ((φ Z ∧ ∃ w, χ w) → (ψ Z ∧ ∃ w, θ w))).
@@ -1384,9 +1384,9 @@ Proof.
       {
         intro Hp.
         pose proof (Simp3_26 (ψ Z) (∃ w, θ w)) as Simp3_26.
-        now Syll Hp Simp3_26 S5_1_1.
+        now Syll_as Hp Simp3_26 S5_1_1.
       }
-      now Syll S5 S5_1_1 S5_1.
+      now Syll_as S5 S5_1_1 S5_1.
     }
     rewrite -> Comm_Equiv in S5_1.
     pose proof (n4_87
@@ -1402,7 +1402,7 @@ Proof.
       (φ Z)
       (∀ z w, φ z ∧ χ w → ψ z ∧ θ w)
       (ψ Z)) as Comm2_04.
-    now Syll S5_1 Comm2_04 S6.
+    now Syll_as S5_1 Comm2_04 S6.
   }
   assert (S7 : (∃ w, χ w) 
     → (((φ z ∧ χ w) -[ z w ]> (ψ z ∧ θ w))
@@ -1430,7 +1430,7 @@ Proof.
         as S3_1. 
       pose proof (n10_28 (fun z => φ z ∧ χ W)
         (fun z => ψ z ∧ θ W)) as n10_28.
-      Syll S3_1 n10_28 S4_1.
+      Syll_as S3_1 n10_28 S4_1.
       (* reordering... *)
       setoid_rewrite -> n4_3 in S4_1 at 3.
       setoid_rewrite -> n4_3 in S4_1 at 4.
@@ -1448,9 +1448,9 @@ Proof.
       {
         intro Hp.
         pose proof (Simp3_26 (θ W) (∃ z, ψ z)) as Simp3_26.
-        now Syll Hp Simp3_26 S5_3_2.
+        now Syll_as Hp Simp3_26 S5_3_2.
       }
-      now Syll S5_2 S5_3_1 S5_3.
+      now Syll_as S5_2 S5_3_1 S5_3.
     }
     rewrite -> Comm_Equiv in S5_3.
     pose proof (n4_87
@@ -1466,7 +1466,7 @@ Proof.
       (χ W)
       (∀ z w, φ z ∧ χ w → ψ z ∧ θ w)
       (θ W)) as Comm2_04.
-    Syll S5_3 Comm2_04 S6_1.
+    Syll_as S5_3 Comm2_04 S6_1.
     pose proof (n10_11 W (fun w0 =>
       (∃ z, φ z) → (∀ z w, φ z ∧ χ w → ψ z ∧ θ w) 
         → χ w0 → θ w0)) as n10_11.
@@ -1490,7 +1490,7 @@ Proof.
       ∧ (((φ z ∧ χ w) -[ z w ]> ψ z ∧ θ w) → (χ w -[ w ]> θ w))).
     {
       clear S2 HS7 HS8.
-      now Conj S7 S8 C1.
+      now Conj_as S7 S8 C1.
     }
     pose proof (Comp3_43 
       (∀ z w, φ z ∧ χ w → ψ z ∧ θ w)
@@ -1507,7 +1507,7 @@ Proof.
     intro Hp.
     pose proof (S9 Hp) as S9.
     clear Hp.
-    Conj S2 S9 C1.
+    Conj_as S2 S9 C1.
     now Equiv C1.
   }
   exact S10.

--- a/pm/ch11.v
+++ b/pm/ch11.v
@@ -8,7 +8,6 @@ Require Import PM.pm.ch9.
 Require Import PM.pm.ch10.
 
 (* TODO: 
-- Design the correct notation for multiple vars
 - Add a special rule: (∃ x, P x ∧ Q x) -> (∃ x, P x) ∧ (∃ x, Q x) 
 *)
 
@@ -106,7 +105,7 @@ Proof.
   assert (S3 : (∀ x y, P ∨ φ x y) → (P ∨ ∀ x y, φ x y)).
   {
     pose proof (n10_12 (fun x => ∀ y, φ x y) P) as n10_12.
-    now Syll_as n10_12 S2 S3.
+    now Syll_as S2 n10_12 S3.
   }
   exact S3.
 Qed.
@@ -179,7 +178,7 @@ Proof.
     now MP n11_12 S4_2.
   }
   assert (S5 : (∀ x y, φ x y) ↔ (∀ y x, φ x y)).
-  { clear S1 S2. Conj_as S3 S4 C1. now Equiv C1. }
+  { Conj_as S3 S4 C1. now Equiv C1. }
   exact S5.
 Qed.  
 
@@ -467,7 +466,7 @@ Proof.
   pose proof (n10_27 (fun x => (∀ y, φ x y ↔ ψ x y))
     (fun x => (∀ y, φ x y) ↔ ∀ y, ψ x y)) as n10_27.
   MP n10_27 n10_11.
-  now Syll_as n10_27 n10_27b S1.
+  now Syll_as n10_27 n10_271b S1.
 Qed.
 
 Theorem n11_34 (φ ψ : Prop → Prop → Prop) :
@@ -483,7 +482,7 @@ Proof.
   MP n10_11 n10_28a.
   pose proof (n10_27 (fun x => (∀ y, φ x y → ψ x y))
     (fun x => (∃ y, φ x y) → ∃ y, ψ x y)) as n10_27.
-  MP n10_27a n10_11.
+  MP n10_27 n10_11.
   pose proof (n10_28 (fun x => ∃ y, φ x y)
     (fun x => ∃ y, ψ x y)) as n10_28b.
   now Syll_as n10_27 n10_28b S1.
@@ -556,7 +555,7 @@ Proof.
       (fun x y =>
         (φ x y → ψ x y) ∧ (ψ x y → χ x y)
         → φ x y → χ x y)) as n11_11.
-    now MP Syll3_33 n11_11.
+    now MP n11_11 Syll3_33.
   }
   assert (S3 : (∀ x y, (φ x y → ψ x y) ∧ (ψ x y → χ x y))
     → (∀ x y, (φ x y → χ x y))).
@@ -877,7 +876,6 @@ Proof.
   assert (S6 : ((∃ x, ¬ ∀ y, φ x y) ↔ ¬ (∀ x y, φ x y))
     ∧ (¬ (∀ x y, φ x y) ↔ (∃ x y, ¬ φ x y))).
   {
-    clear S1 S3 S4.
     (* ??????? *)
     rewrite -> S2 in S5.
     now Conj_as S2 S5 S6.
@@ -904,7 +902,7 @@ Proof.
   {
     pose proof (n10_11 X (fun x =>
       (¬ (∀ y, φ x y) ↔ ∃ y, ¬ φ x y))) as n10_11.
-    MP S2 n10_11.
+    MP n10_11 S2.
     pose proof (n10_271 (fun x => ¬ (∀ y, φ x y))
       (fun x => ∃ y, ¬ φ x y)) as n10_271.
     now MP n10_271 n10_11.
@@ -936,7 +934,7 @@ Proof.
     pose proof (n11_11 X Y
       (fun x y => ¬ (φ x y ∧ ψ x y) ↔ (φ x y → ¬ ψ x y)))
       as n11_11.
-    MP n11_11 S2.
+    MP n11_11 S1.
     pose proof (n11_33 (fun x y => ¬ (φ x y ∧ ψ x y))
       (fun x y => φ x y → ¬ ψ x y)) as n11_33.
     now MP n11_33 n11_11.
@@ -1109,7 +1107,7 @@ Proof.
       (fun x y => φ x ∧ φ y → ψ x ∧ ψ y)) as n11_32.
     MP n11_32 n11_11.
     destruct S1 as [S1l _].
-    now Syll_as S1 n11_32 S2.
+    now Syll_as S1l n11_32 S2.
   }
   assert (S3 : (∀ x y, (φ x ∧ φ y) → (ψ x ∧ ψ y)) 
     → ((φ X ∧ φ Y) → (ψ X ∧ ψ Y))).
@@ -1144,7 +1142,6 @@ Proof.
   assert (S6 : (φ x -[ x ]> ψ x) ↔
     ((φ x ∧ φ y) -[ x y ]> (ψ x ∧ ψ y))).
   {
-    clear S1 S3 S4.
     Conj_as S2 S5 S6.
     now Equiv S6.
   }
@@ -1215,13 +1212,13 @@ Proof.
   {
     pose proof (n10_11 X (fun x => (∃ y, φ x → ψ x y) 
       → (φ x → ∃ y, ψ x y))) as n10_11.
-    MP n10_11 S1.
+    MP n10_11 S2.
     pose proof (n10_27 (fun x => ∃ y, φ x → ψ x y)
       (fun x => φ x → ∃ y, ψ x y)) as n10_27.
     now MP n10_27 n10_11.
   }
   assert (S4 : (∃ y, (φ x -[ x ]> ψ x y)) → (φ x -[ x ]> ∃ y, ψ x y)).
-  { clear S2. now Syll_as S1 S3 S4. }
+  { now Syll_as S1 S3 S4. }
   exact S4.
 Qed.
 
@@ -1327,11 +1324,7 @@ Proof.
   {
     pose proof (n10_1 (fun z => φ z → ψ z) Z) as n10_1a.
     pose proof (n10_1 (fun w => χ w → θ w) W) as n10_1b.
-    assert (C1 :
-      ((φ x -[ x ]> ψ x) → (φ Z → ψ Z))
-      ∧
-      ((χ x -[ x ]> θ x) → (χ W →θ W))).
-    { now Conj_as n10_1a n10_1b C1. }
+    Conj_as n10_1a n10_1b C1.
     pose proof (n3_47
       (φ z -[ z ]> ψ z) (χ w -[ w ]> θ w)
       (φ Z → ψ Z) (χ W → θ W)) as n3_47a.
@@ -1396,7 +1389,6 @@ Proof.
         → ψ Z)) as n4_87.
     destruct n4_87 as [n4_87 _].
     rewrite -> n4_87 in S5_1.
-    clear n4_87.
     rewrite -> Comm_Equiv in S5_1.
     pose proof (Comm2_04 
       (φ Z)
@@ -1415,13 +1407,11 @@ Proof.
     rewrite -> n10_21 in n10_11.
     now setoid_rewrite -> n10_21 in n10_11.
   }
-  clear S1 S3 S4 S5 S6.
   (* Similarly?! Wdym by similarly?!! *)
   assert (S8 : (∃ z, φ z) 
     → (((φ z ∧ χ w) -[ z w ]> (ψ z ∧ θ w))
       → (χ w -[ w ]> θ w))).
   {
-    clear S7.
     assert (S5_2 : (∀ z w, (φ z ∧ χ w) → ψ z ∧ θ w)
       → (χ W ∧ (∃ z, φ z) → (θ W ∧ ∃ z, ψ z))).
     {
@@ -1460,7 +1450,6 @@ Proof.
         → θ W)) as n4_87.
     destruct n4_87 as [n4_87 _].
     rewrite -> n4_87 in S5_3.
-    clear n4_87.
     rewrite -> Comm_Equiv in S5_3.
     pose proof (Comm2_04 
       (χ W)
@@ -1485,13 +1474,7 @@ Proof.
     destruct Hp as [HS8 HS7].
     pose proof (S7 HS7) as S7.
     pose proof (S8 HS8) as S8.
-    assert (C1 : 
-      (((φ z ∧ χ w) -[ z w ]> ψ z ∧ θ w) → (φ z -[ z ]> ψ z))
-      ∧ (((φ z ∧ χ w) -[ z w ]> ψ z ∧ θ w) → (χ w -[ w ]> θ w))).
-    {
-      clear S2 HS7 HS8.
-      now Conj_as S7 S8 C1.
-    }
+    Conj_as S7 S8 C1.
     pose proof (Comp3_43 
       (∀ z w, φ z ∧ χ w → ψ z ∧ θ w)
       (∀ z, φ z → ψ z)
@@ -1502,11 +1485,9 @@ Proof.
     → (((φ z -[ z ]> ψ z) ∧ (χ w -[ w ]> θ w))
       ↔ ((φ z ∧ χ w) -[ z w ]> (ψ z ∧ θ w)))).
   {
-    clear S7 S8.
     (* Similarly, we save the rountine *)
     intro Hp.
     pose proof (S9 Hp) as S9.
-    clear Hp.
     Conj_as S2 S9 C1.
     now Equiv C1.
   }

--- a/pm/ch13.v
+++ b/pm/ch13.v
@@ -101,7 +101,7 @@ Proof.
     (* The following two can be obtained with `n10_1` *)
     pose proof (Hn12_1 X) as Hn12_1a.
     pose proof (Hn12_1 Y) as Hn12_1b.
-    Conj Hn12_1a Hn12_1b C1.
+    Conj_as Hn12_1a Hn12_1b C1.
     pose proof (n10_24_pred
       (fun (f : Order 1) => (ψ X ↔ f X) ∧ (ψ Y ↔ f Y))
       If) as n10_24.
@@ -161,7 +161,7 @@ Proof.
       in n10_22l by reflexivity.
     pose proof (Simp3_26 (∀ p : Order 1, p X -> p Y)
       (∀ p : Order 1, p Y -> p X)) as Simp3_26.
-    now Syll n10_22l Simp3_26 S1.
+    now Syll_as n10_22l Simp3_26 S1.
   }
   assert (S2 : (∀ φ : Order 1, φ X ↔ φ Y)
     → (X = Y)).
@@ -177,7 +177,7 @@ Proof.
   assert (S5 : (X = Y) → (Iφ Y → Iφ X)).
   {
     pose proof (Transp2_17 (Iφ Y) (Iφ X)) as Transp2_17.
-    now Syll S4 Transp2_17 S5.
+    now Syll_as S4 Transp2_17 S5.
   }
   assert (S6 : (X = Y) → (Iφ X ↔ Iφ Y)).
   {
@@ -186,7 +186,7 @@ Proof.
     assert (C1 : (X = Y → Iφ X → Iφ Y) ∧ (X = Y → Iφ Y → Iφ X)).
     { 
       clear S1 S2 S4.
-      now Conj S3 S5 C1.
+      now Conj_as S3 S5 C1.
     }
     MP Comp3_43 C1.
     now rewrite <-Equiv4_01 in Comp3_43.
@@ -205,7 +205,7 @@ Proof.
     clear S1 S3 S4 S5 S6. move S2 after S7.
     assert (C1 : (X = Y → ∀ φ : Order 1, φ X ↔ φ Y)
       ∧ ((∀ φ : Order 1, φ X ↔ φ Y) → X = Y)).
-    { now Conj S7 S2 C1. }
+    { now Conj_as S7 S2 C1. }
     now Equiv C1.
   }
   exact S8.
@@ -229,7 +229,7 @@ Proof.
     pose proof (Transp2_17 (ψ Y) (ψ X)) as Transp2_17.
     MP Transp2_17 S1_1r.
     assert (C1 : (ψ X → ψ Y) ∧ (ψ Y → ψ X)).
-    { now Conj S1_1l Transp2_17 C1. }
+    { now Conj_as S1_1l Transp2_17 C1. }
     now Equiv C1.
   }
   exact S2.
@@ -284,7 +284,7 @@ Proof.
     destruct n13_1a as [n13_1al _].
     pose proof (n13_1 Y Z) as n13_1b.
     destruct n13_1b as [n13_1bl _].
-    Conj n13_1al n13_1bl C1.
+    Conj_as n13_1al n13_1bl C1.
     pose proof (n3_47 (X = Y) (Y = Z)
       (∀ (p : Order 1), p X -> p Y)
       (∀ (p : Order 1), p Y -> p Z)) as n3_47.
@@ -353,7 +353,7 @@ Proof.
   assert (C1 : (X = Y → Z = X → Z = Y) ∧ (X = Y → Z = Y → Z = X)).
   {
     clear n13_17 n13_172 n13_16a n13_16b n13_16c.
-    now Conj Exp3_3a Exp3_3b C1.
+    now Conj_as Exp3_3a Exp3_3b C1.
   }
   MP Comp3_43 C1.
   now rewrite <- Equiv4_01 in Comp3_43.
@@ -402,7 +402,7 @@ Proof.
   {
     assert (C1 : (X = Y → ∀ z : Prop, X = z ↔ z = Y)
       ∧ ((∀ z : Prop, X = z ↔ z = Y) → X = Y)).
-    { clear S2. now Conj S1 S3 C1. }
+    { clear S2. now Conj_as S1 S3 C1. }
     now Equiv C1.
   }
   exact S4.
@@ -458,7 +458,7 @@ Proof.
   assert (S6 : ((y = X) -[ y ]> φ y) ↔ φ X).
   {
     clear S1 S3 S4.
-    Conj S2 S5 C1.
+    Conj_as S2 S5 C1.
     now Equiv C1.
   }
   exact S6.
@@ -483,7 +483,7 @@ Proof.
   {
     pose proof (n10_24 (fun c =>
       (x = B <[- x -]> x = c) ∧ ψ c) B) as n10_24.
-    now Syll S1 n10_24 S2.
+    now Syll_as S1 n10_24 S2.
   }
   assert (S3 : ((x = B <[- x -]> x = C) ∧ (ψ C)) 
     → (((B = B) ↔ (B = C)) ∧ ψ C)).
@@ -507,7 +507,7 @@ Proof.
     pose proof (n13_16 B C) as n13_16.
     rewrite <- n13_16 in n13_13.
     rewrite -> n4_3 in n13_13.
-    now Syll S4 n13_13 S5.
+    now Syll_as S4 n13_13 S5.
   }
   assert (S6 : (∃ c, ((x = B <[- x -]> x = c) ∧ ψ c)) → ψ B).
   {
@@ -523,7 +523,7 @@ Proof.
   {
     clear S1 S3 S4 S5.
     move S2 after S6.
-    Conj S6 S2 C1.
+    Conj_as S6 S2 C1.
     now Equiv C1.
   }
   exact S7.
@@ -539,7 +539,7 @@ Proof.
   assert (S3 : (φ X ∧ (X = Y)) → (φ Y ∧ (X = Y))).
   {
     move S1 after S2.
-    Conj S2 S1 C1.
+    Conj_as S2 S1 C1.
     pose proof (Comp3_43 (φ X ∧ (X = Y)) (φ Y) (X = Y)) as Comp3_43.
     now MP Comp3_43 C1.
   }
@@ -575,7 +575,7 @@ Proof.
   assert (S7 : (φ X ∧ (X = Y)) ↔ (φ Y ∧ (X = Y))).
   {
     clear S1 S2 S4 S5.
-    Conj S3 S6 C1.
+    Conj_as S3 S6 C1.
     now Equiv C1.
   }
   exact S7.
@@ -604,7 +604,7 @@ Proof.
   assert (S2 : φ X → (∃ y, (y = X) ∧ φ y)).
   {
     pose proof (n10_24 (fun y => y = X ∧ φ y) X) as n10_24.
-    now Syll S1 n10_24 S2.
+    now Syll_as S1 n10_24 S2.
   }
   assert (S3 : ∀ y, ((y = X) ∧ φ y) → φ X).
   {
@@ -619,7 +619,7 @@ Proof.
   {
     clear S1 S3.
     move S2 after S4.
-    Conj S4 S2 C1.
+    Conj_as S4 S2 C1.
     now Equiv C1.
   }
   exact S5.
@@ -692,14 +692,14 @@ Proof.
     (* n10_13 ignored - we directly use `Conj` instead. Is it legal? *)
     (* n10_221 ignored *)
     clear S1 S2 S3.
-    now Conj S4 S5 C1.
+    now Conj_as S4 S5 C1.
   }
   assert (S7 : ((φ A ∨ ¬ φ A) → φ X ∨ ¬ φ X)
     ∧ ((φ A ∨ ¬ φ A) → (X = A ∨ (X ≠ A)))
     ∧ ((φ A ∨ ¬ φ A) → ((X = A) → (φ X ∨ ¬ φ X)))).
   {
     clear S1 S3 S4 S5.
-    now Conj S2 S6 C1.
+    now Conj_as S2 S6 C1.
   }
   assert (S8 : ((φ A ∨ ¬ φ A) → φ X ∨ ¬ φ X)
     ∧ ((φ A ∨ ¬ φ A) → (X = A ∨ (X ≠ A)))).

--- a/pm/ch13.v
+++ b/pm/ch13.v
@@ -134,7 +134,6 @@ Proof.
   {
     intro Hp.
     pose proof (S4 Hp) as S4.
-    clear S2 S3.
     now MP S4 S1.
   }
   exact S5.
@@ -183,11 +182,7 @@ Proof.
   {
     pose proof (Comp3_43 (X = Y) (Iφ X → Iφ Y) (Iφ Y → Iφ X))
       as Comp3_43.
-    assert (C1 : (X = Y → Iφ X → Iφ Y) ∧ (X = Y → Iφ Y → Iφ X)).
-    { 
-      clear S1 S2 S4.
-      now Conj_as S3 S5 C1.
-    }
+    Conj_as S3 S5 C1.
     MP Comp3_43 C1.
     now rewrite <-Equiv4_01 in Comp3_43.
   }
@@ -201,13 +196,7 @@ Proof.
     now rewrite -> n10_21 in n10_11.
   }
   assert (S8 : (X = Y) ↔ (∀ φ : Order 1, (φ X) ↔ (φ Y))).
-  {
-    clear S1 S3 S4 S5 S6. move S2 after S7.
-    assert (C1 : (X = Y → ∀ φ : Order 1, φ X ↔ φ Y)
-      ∧ ((∀ φ : Order 1, φ X ↔ φ Y) → X = Y)).
-    { now Conj_as S7 S2 C1. }
-    now Equiv C1.
-  }
+  { Conj_as S7 S2 C1. now Equiv C1. }
   exact S8.
 Admitted.
 
@@ -228,8 +217,7 @@ Proof.
     destruct S1 as [S1_1l S1_1r].
     pose proof (Transp2_17 (ψ Y) (ψ X)) as Transp2_17.
     MP Transp2_17 S1_1r.
-    assert (C1 : (ψ X → ψ Y) ∧ (ψ Y → ψ X)).
-    { now Conj_as S1_1l Transp2_17 C1. }
+    Conj_as S1_1l Transp2_17 C1.
     now Equiv C1.
   }
   exact S2.
@@ -350,11 +338,7 @@ Proof.
   MP Exp3_3b n13_172.
   pose proof (Comp3_43
     (X = Y) (Z = X → Z = Y) (Z = Y → Z = X)) as Comp3_43.
-  assert (C1 : (X = Y → Z = X → Z = Y) ∧ (X = Y → Z = Y → Z = X)).
-  {
-    clear n13_17 n13_172 n13_16a n13_16b n13_16c.
-    now Conj_as Exp3_3a Exp3_3b C1.
-  }
+  Conj_as Exp3_3b Exp3_3a C1.
   MP Comp3_43 C1.
   now rewrite <- Equiv4_01 in Comp3_43.
 Qed.
@@ -399,12 +383,7 @@ Proof.
     now MP S2 n13_15.
   }
   assert (S4 : (X = Y) ↔ ((X = z) <[- z -]> (z = Y))).
-  {
-    assert (C1 : (X = Y → ∀ z : Prop, X = z ↔ z = Y)
-      ∧ ((∀ z : Prop, X = z ↔ z = Y) → X = Y)).
-    { clear S2. now Conj_as S1 S3 C1. }
-    now Equiv C1.
-  }
+  { Conj_as S1 S3 C1. now Equiv C1. }
   exact S4.
 Qed.
 
@@ -456,11 +435,7 @@ Proof.
     now rewrite -> n10_21 in n10_11.
   }
   assert (S6 : ((y = X) -[ y ]> φ y) ↔ φ X).
-  {
-    clear S1 S3 S4.
-    Conj_as S2 S5 C1.
-    now Equiv C1.
-  }
+  { Conj_as S2 S5 C1. now Equiv C1. }
   exact S6.
 Qed.
 
@@ -520,12 +495,7 @@ Proof.
     now rewrite -> n10_23 in n10_11.
   }
   assert (S7 : (∃ c, ((x = B) <[- x -]> (x = c)) ∧ ψ c) ↔ ψ B).
-  {
-    clear S1 S3 S4 S5.
-    move S2 after S6.
-    Conj_as S6 S2 C1.
-    now Equiv C1.
-  }
+  { Conj_as S6 S2 C1. now Equiv C1. }
   exact S7.
 Qed.
 
@@ -538,7 +508,6 @@ Proof.
   { apply n13_13. }
   assert (S3 : (φ X ∧ (X = Y)) → (φ Y ∧ (X = Y))).
   {
-    move S1 after S2.
     Conj_as S2 S1 C1.
     pose proof (Comp3_43 (φ X ∧ (X = Y)) (φ Y) (X = Y)) as Comp3_43.
     now MP Comp3_43 C1.
@@ -573,11 +542,7 @@ Proof.
     now rewrite <- n13_16 in S5.
   }
   assert (S7 : (φ X ∧ (X = Y)) ↔ (φ Y ∧ (X = Y))).
-  {
-    clear S1 S2 S4 S5.
-    Conj_as S3 S6 C1.
-    now Equiv C1.
-  }
+  { Conj_as S3 S6 C1. now Equiv C1. }
   exact S7.
 Qed.
 
@@ -616,12 +581,7 @@ Proof.
   assert (S4 : (∃ y, (y = X) ∧ φ y) → φ X).
   { now rewrite -> n10_23 in S3. }
   assert (S5 : (∃ y, (y = X) ∧ φ y) ↔ φ X).
-  {
-    clear S1 S3.
-    move S2 after S4.
-    Conj_as S4 S2 C1.
-    now Equiv C1.
-  }
+  { Conj_as S4 S2 C1. now Equiv C1. }
   exact S5.
 Qed.
 
@@ -691,16 +651,12 @@ Proof.
   {
     (* n10_13 ignored - we directly use `Conj` instead. Is it legal? *)
     (* n10_221 ignored *)
-    clear S1 S2 S3.
     now Conj_as S4 S5 C1.
   }
   assert (S7 : ((φ A ∨ ¬ φ A) → φ X ∨ ¬ φ X)
     ∧ ((φ A ∨ ¬ φ A) → (X = A ∨ (X ≠ A)))
     ∧ ((φ A ∨ ¬ φ A) → ((X = A) → (φ X ∨ ¬ φ X)))).
-  {
-    clear S1 S3 S4 S5.
-    now Conj_as S2 S6 C1.
-  }
+  { now Conj_as S2 S6 C1. }
   assert (S8 : ((φ A ∨ ¬ φ A) → φ X ∨ ¬ φ X)
     ∧ ((φ A ∨ ¬ φ A) → (X = A ∨ (X ≠ A)))).
   {

--- a/pm/ch13.v
+++ b/pm/ch13.v
@@ -592,7 +592,7 @@ Proof.
   rewrite -> Transp4_11 in n13_195.
   setoid_rewrite -> n4_3 in n13_195 at 2.
   rewrite -> n10_51 in n13_195.
-  now symmetry in n13_195.
+  now rewrite -> n4_21 in n13_195.
 Qed.
 
 Theorem n13_21 (X Y : Prop) (φ : Prop → Prop → Prop) : 

--- a/pm/ch14.v
+++ b/pm/ch14.v
@@ -366,13 +366,9 @@ Proof.
     pose proof (S2 Hp) as S2.
     destruct S2 as [A1 A2].
     destruct A2 as [A2l _].
-    assert (S2_1 : φ B ∧ (φ B → B = C)).
-    { 
-      clear S1.
-      now Conj_as A1 A2l S2_1. 
-    }
+    Conj_as A1 A2l C1. 
     pose proof (Ass3_35 (φ B) (B = C)) as Ass3_35.
-    now MP Ass3_35 S2_1.
+    now MP Ass3_35 C1.
   }
   exact S3.
 Admitted.
@@ -431,10 +427,7 @@ Proof.
   assert (S8 : ((φ x <[- x -]> (x = B)) ↔ ((φ x -[ x ]> (x = B)) ∧ φ B))
     ∧ (((φ x -[ x ]> (x = B)) ∧ φ B) 
       ↔ ((φ x -[ x ]> (x = B)) ∧ ∃ x, φ x))).
-  {
-    clear S1 S3 S4 S5 S6.
-    now Conj_as S2 S7 S8.
-  }
+  { now Conj_as S2 S7 S8. }
   exact S8.
 Qed.
 
@@ -481,7 +474,7 @@ Proof.
       (φ z w → ((z = X) ∧ (w = Y)))
         → (φ z w ↔ (φ z w 
           ∧ (z = X) ∧ (w = Y))))) as n11_11.
-    MP n11_11 S4.
+    MP n11_11 S3.
     pose proof (n11_32 (fun z w => φ z w → ((z = X) ∧ (w = Y)))
       (fun z w => φ z w ↔ (φ z w 
         ∧ (z = X) ∧ (w = Y)))) as n11_32.
@@ -493,7 +486,7 @@ Proof.
   {
     pose proof (n11_341 φ (fun z w => 
       φ z w ∧ (z = X) ∧ (w = Y))) as n11_341.
-    now Syll_as n11_341 S4 S5.
+    now Syll_as S4 n11_341 S5.
   }
   assert (S6 : (φ z w -[ z w ]> ((z = X) ∧ (w = Y)))
     → ((∃ z w, φ z w) ↔ φ X Y)).
@@ -510,10 +503,7 @@ Proof.
       ↔ ((φ z w -[ z w ]> (z = X ∧ w = Y)) ∧ φ X Y))
     ∧ (((φ z w -[ z w ]> (z = X ∧ w = Y)) ∧ φ X Y)
       ↔ ((φ z w -[ z w ]> (z = X ∧ w = Y)) ∧ ∃ z w, φ z w))).
-  {
-    clear S1 S3 S4 S5 S6.
-    now Conj_as S2 S7 S8.
-  }
+  { now Conj_as S2 S7 S8. }
   exact S8.
 Qed.
 
@@ -539,7 +529,7 @@ Proof.
     pose proof (Simp3_27
       (φ z w -[ z w ]> z = X ∧ w = Y)
       (φ X Y)) as Simp3_27.
-    Syll_as n14_123l Simp3_27 Sy1.
+    Syll_as n14_123ll Simp3_27 Sy1.
     pose proof (n11_11 X Y (fun x y =>
       (φ z w <[- z w -]> z = x ∧ w = y) → φ x y)) as n11_11.
     MP n11_11 Sy1.
@@ -575,14 +565,13 @@ Proof.
     assert (S2_1 : (Z = X ∧ W = Y ∧ U = X ∧ V = Y)
       ↔ ((Z = X ∧ U = X) ∧ (W = Y ∧ V = Y))).
     { now rewrite <- n4_32. }
-    rewrite -> S2_1 in S2. clear S2_1.
+    rewrite -> S2_1 in S2.
     pose proof (n13_172 X Z U) as n13_172a.
     pose proof (n13_172 Y W V) as n13_172b.
     pose proof (n3_47
       (Z = X ∧ U = X) (W = Y ∧ V = Y)
       (Z = U) (W = V)) as n3_47.
-    assert (C1 : (Z = X ∧ U = X → Z = U) ∧ (W = Y ∧ V = Y → W = V)).
-    { clear n3_47; now Conj_as n13_172a n13_172b C1. }
+    Conj_as n13_172a n13_172b C1.
     MP n3_47 C1.
     (* simplification for syll *)
     now Syll_as S2 n3_47 S3.
@@ -684,19 +673,13 @@ Proof.
     ↔ (∃ x y, φ x y) 
       ∧ (φ z w ∧ φ u v) -[ z w u v ]> (z = u ∧ w = v)).
   {
-    clear S2 S3 S4 S6 S7 S8.
-    assert (C1 : ((∃ x y,  φ z w <[- z w -]> z = x ∧ w = y) → ∃ x y : Prop, φ x y)
-      ∧ ((∃ x y,  φ z w <[- z w -]> z = x ∧ w = y)
-        → (φ z w ∧ φ u v) -[ z w u v ]> (z = u ∧ w = v))).
-    { clear S9. now Conj_as S1 S5 C1. }
+    Conj_as S1 S5 C1.
     pose proof (Comp3_43
       (∃ x y, φ z w <[- z w -]> z = x ∧ w = y)
       (∃ x y, φ x y)
       ((φ z w ∧ φ u v) -[ z w u v ]> (z = u ∧ w = v)))
       as Comp3_43.
     MP Comp3_43 C1.
-    clear S1 S5 C1.
-    move S9 after Comp3_43.
     Conj_as Comp3_43 S9 S10.
     now Equiv S10.
   }
@@ -914,13 +897,7 @@ Proof.
     destruct n14_112a as [n14_112al _].
     pose proof (n14_112 ψ χ (fun x y => x = y)) as n14_112b.
     destruct n14_112b as [n14_112bl _].
-    assert (C1 : ([ι2 φ, ψ | ιφ ιψ => ιφ = ιψ]
-        → ∃ b c, (φ x <[- x -]> x = b) 
-          ∧ (ψ x <[- x -]> x = c) ∧ b = c)
-      ∧ ([ι2 ψ, χ | ιψ ιχ => ιψ = ιχ]
-      → ∃ b c, (ψ x <[- x -]> x = b)
-          ∧ (χ x <[- x -]> x = c) ∧ b = c)).
-    { now Conj_as n14_113al n14_113bl C1. }
+    Conj_as n14_112al n14_112bl C1.
     pose proof (n3_47
       ([ι2 φ, ψ | ιφ ιψ => ιφ = ιψ])
       ([ι2 ψ, χ | ιψ ιχ => ιψ = ιχ])
@@ -951,7 +928,6 @@ Proof.
     setoid_rewrite -> n13_16 in S1r at 1.
     setoid_rewrite -> n13_195 in S1r.
     setoid_rewrite -> n4_3 in S1r.
-    clear Hp.
     now Conj_as S1l S1r C1.
   }
   assert (S3 : ([ι2 φ, ψ | ιφ ιψ => ιφ = ιψ]
@@ -980,7 +956,6 @@ Proof.
     setoid_rewrite <- n4_32 in S3.
     setoid_rewrite -> n4_3 in S3 at 2.
     setoid_rewrite -> n4_3 in S3.
-    clear Hp.
     (* Now we are going to construct something, "bottom up",
     with ad-hoc individuals *)
     pose proof (n14_121 X Y ψ) as n14_121.
@@ -1003,7 +978,6 @@ Proof.
         ∧ (φ x0 <[- x0 -]> x0 = x) ∧ χ x0 <[- x0 -]> x0 = y)) 
       as n11_34.
     MP n11_34 n11_11.
-    clear n4_32 n14_121 Fact3_45 n11_11.
     MP n11_34 S3.
     setoid_rewrite -> n4_3 in n11_34.
     now setoid_rewrite -> n4_32 in n11_34.
@@ -1035,9 +1009,7 @@ Proof.
       (ψ x <[- x -]> (x = b)) ∧ (A = b)))).
   {
     pose proof (n14_1 ψ (fun x => A = x)) as n14_1.
-    assert (C1 : ([ι φ | ιφ => A = ιφ] ↔ φ x <[- x -]> x = A)
-      ∧ ([ι ψ | ιψ => A = ιψ] ↔ ∃ b, (ψ x <[- x -]> x = b) ∧ A = b)).
-    { clear S1. now Conj_as S2 n14_1 C1. }
+    Conj_as S2 n14_1 C1.
     pose proof (n4_38
       ([ι φ | ιφ => A = ιφ])
       ([ι ψ | ιψ => A = ιψ])
@@ -1055,7 +1027,7 @@ Proof.
     destruct S4 as [S4 _].
     pose proof (n10_24 (fun a => ∃ b, (φ x <[- x -]> x = a) 
       ∧ (ψ x <[- x -]> x = b) ∧ a = b) A) as n10_24.
-    Syll_as n10_24 S4 S4_1.
+    Syll_as S4 n10_24 S4_1.
     now rewrite <- n14_112 in S4_1.
   }
   exact S5.
@@ -1134,11 +1106,7 @@ Proof.
   assert (S5 : ((φ x <[- x -]> (x = B)) ∧ [ι ψ | ιψ => B = ιψ])
     → ([ι φ | ιφ => χ ιφ] ↔ [ι ψ | ιψ => χ ιψ])).
   {
-    assert (C1 : ((∀ x : Prop, φ x ↔ x = B) 
-        → [ι φ | ιφ => χ ιφ] ↔ χ B)
-      ∧ ([ι ψ | ιψ => B = ιψ]
-        → χ B ↔ [ι ψ | ιψ => χ ιψ])).
-    { clear S1 S2. now Conj_as S3 S4 C1. }
+    Conj_as S3 S4 C1.
     pose proof (n3_47
       (φ x <[- x -]> x = B)
       ([ι ψ | ιψ => B = ιψ])
@@ -1195,10 +1163,7 @@ Proof.
     (* right part of the ∧ *)
     pose proof (n10_1_pred (fun x : Order 1 => 
       [ι φ | ιφ => x ιφ] ↔ x B) Iχ) as n10_1b.
-    assert (C1 : ((∀ x, Iχ x ↔ x = B) → Iχ B ↔ B = B)
-      ∧ ((∀ x : Order 1, [ι φ | ιφ => x ιφ] ↔ x B)
-        → [ι φ | ιφ => Iχ ιφ] ↔ Iχ B)).
-    { now Conj_as n10_1a n10_1b C1. }
+    Conj_as n10_1a n10_1b C1.
     pose proof (n3_47
       (∀ x, Iχ x ↔ x = B)
       (∀ x : Order 1, [ι φ | ιφ => x ιφ] ↔ x B)
@@ -1207,7 +1172,6 @@ Proof.
     MP n3_47 C1.
     pose proof (n4_22 ([ι φ | ιφ => Iχ ιφ]) (Iχ B)
       (B = B)) as n4_22.
-    clear n10_1a n10_1b C1.
     rewrite -> n4_3 in n4_22.
     Syll_as n3_47 n4_22 Sy1.
     (* We can see that in the original text, `Iχ` has been substituted into
@@ -1216,12 +1180,10 @@ Proof.
     a concrete definition, by applying n10_1 and n10_11 variants *)
     pose proof (n10_11_pred Iχ (fun p => 
       [ι φ | ιφ => p ιφ] ↔ B = B)) as n10_11a.
-    clear n3_47 n4_22.
     Syll_as Sy1 n10_11a Sy2.
     pose proof (n10_1_pred
       (fun p => [ι φ | ιφ => p ιφ] ↔ B = B)
       (fun x => x = B)) as n10_1c.
-    clear Sy1 n10_11a.
     now Syll_as Sy2 n10_1c S2.
   }
   assert (S3 : ((Iχ x <[- x -]> (x = B)) 
@@ -1260,14 +1222,7 @@ Proof.
   { now MP S4 S5. }
   assert (S7 : [ι φ | ιφ => ιφ = B]
     ↔ (∀ ψ : Order 1, [ι φ | ιφ => ψ ιφ] ↔ ψ B)).
-  {
-    assert (C1 : ([ι φ | ιφ => ιφ = B]
-        → ∀ ψ : Order 1, [ι φ | ιφ => ψ ιφ]↔ ψ B)
-      ∧ ((∀ ψ : Order 1, [ι φ | ιφ => ψ ιφ] ↔ ψ B)
-        → [ι φ | ιφ => ιφ = B])).
-    { clear S2 S3 S4 S5. now Conj_as S1 S6 C1. }
-    now Equiv C1.
-  }
+  { Conj_as S1 S6 C1. now Equiv C1. }
   exact S7.
 Admitted.
 
@@ -1297,11 +1252,7 @@ Proof.
   }
   assert (S4 : [ι φ | ιφ => ιφ = B]
     ↔ (∀ ψ : Order 1, ψ B → [ι φ | ιφ => ψ ιφ])).
-  {
-    clear S2.
-    Conj_as S1 S3 C1.
-    now Equiv C1.
-  }
+  { Conj_as S1 S3 C1. now Equiv C1. }
   exact S4.
 Admitted.
 
@@ -1444,10 +1395,7 @@ Proof.
       rewrite -> n4_21 in S3_3.
       now setoid_rewrite -> n13_16 in S3_3 at 1.
     }
-    assert (C1 : ([ι φ | ιφ => ιφ = B] ↔ (φ x <[- x -]> B = x))
-      ∧ ((φ x <[- x -]> B = x) ↔ [ι φ | ιφ => B = ιφ])).
-    { clear S3_1. now Conj_as S3_2 S3_3 C1. }
-    clear S2 S3_2 S3_3.
+    Conj_as S3_2 S3_3 C1.
     now Conj_as S3_1 C1 S3.
   }
   exact S3.
@@ -1545,11 +1493,7 @@ Proof.
   { now rewrite <- n14_11 in S7. }
   assert (S9 : [ιE φ]
     ↔ ((∃ x, φ x) ∧ ((φ x ∧ φ y)) -[ x y ]> (x = y))).
-  {
-    clear S2 S3 S4 S5 S6 S7.
-    Conj_as S1 S8 S9.
-    now Equiv S9.
-  }
+  { Conj_as S1 S8 S9. now Equiv S9. }
   exact S9.
 Qed.
 
@@ -1678,10 +1622,7 @@ Proof.
   { apply n14_21. }
   assert (S4 : [ιE (fun x => φ x ∧ ψ x)]
     ↔ [ι (fun x => φ x ∧ ψ x) | ι1 => φ ι1]).
-  {
-    clear S1. 
-    now Syll_as S2 S3 S4.
-  }
+  { now Syll_as S2 S3 S4. }
   exact S4.
 Qed.
 
@@ -1746,7 +1687,6 @@ Proof.
     intro Hp.
     pose proof (S2 Hp) as S2.
     pose proof (n10_11 X (fun x => φ Y -> (φ x -> Y = x))) as n10_11.
-    clear S1.
     MP n10_11 S2.
     now rewrite -> n10_21 in n10_11.
   }
@@ -1779,7 +1719,6 @@ Proof.
     intro Hp.
     pose proof (S7 Hp) as S7.
     pose proof (n10_11 Y (fun y => φ y ↔ [ι φ | ιφ => y = ιφ])) as n10_11.
-    clear S1 S2 S3 S4 S5 S6.
     now MP n10_11 S7.
   }
   exact S8.
@@ -1892,7 +1831,6 @@ Proof.
   {
     (* simplifications *)
     intro Hp.
-    clear S2 S3 S4 S5.
     pose proof (S1 Hp) as S1.
     MP S6 S1.
     pose proof (n14_25 φ ψ) as n14_25.
@@ -2002,7 +1940,6 @@ Proof.
     pose proof (S2 Hp) as S2.
     pose proof (n10_271 (fun x => φ x ↔ (x = B))
       (fun x => ψ x ↔ (x = B))) as n10_271.
-    clear S1.
     now MP n10_271 S2.
   }
   assert (S4 : (φ x <[- x -]> ψ x) -> ∀ b, (∀ x, φ x ↔ (x = b)) 
@@ -2018,7 +1955,7 @@ Proof.
   {
     pose proof (n10_281 (fun b => φ x <[- x -]> (x = b))
       (fun b => ψ x <[- x -]> (x = b))) as n10_281.
-    now Syll_as n10_281 S4 S5.
+    now Syll_as S4 n10_281 S5.
   }
   assert (S6 : (φ x <[- x -]> ψ x) → ([ιE φ] ↔ [ιE ψ])).
   { now repeat rewrite <- n14_02 in S5. }
@@ -2063,7 +2000,6 @@ Proof.
     pose proof (Fact3_45 (ψ x <[- x -]> x = B) 
       (φ x <[- x -]> x = B) (χ B)) as Fact3_45b.
     MP Fact3_45b S2r.
-    clear S1 S2l S2r Hp.
     Conj_as Fact3_45a Fact3_45b S3.
     now Equiv S3.
   }
@@ -2225,7 +2161,6 @@ Proof.
       ↔ (P ∨ [ι φ | ιφ => χ ιφ]))).
   {
     (* simplification *)
-    clear S2.
     intro Hp.
     pose proof (S1 Hp) as S1.
     pose proof (S3 Hp) as S3.
@@ -2270,7 +2205,6 @@ Proof.
       ↔ ¬ [ι φ | ιφ => χ ιφ])).
   {
     (* simplification *)
-    clear S2.
     intro Hp.
     pose proof (S1 Hp) as S1.
     pose proof (S3 Hp) as S3.
@@ -2297,11 +2231,7 @@ Proof.
   }
   assert (S7 : [ιE φ] ↔ (([ι φ | ιφ => ¬ χ ιφ])
     ↔ ¬ [ι φ | ιφ => χ ιφ])).
-  {
-    clear S1 S2 S3 S4.
-    Conj_as S5 S6 S7.
-    now Equiv S7.
-  }
+  { Conj_as S5 S6 S7. now Equiv S7. }
   exact S7.
 Admitted.
 
@@ -2333,7 +2263,6 @@ Proof.
     intro Hp.
     pose proof (S2 Hp) as S2.
     pose proof (n4_85 ([ι φ | ιφ => χ ιφ]) (χ B) P) as n4_85.
-    clear S1.
     now MP n4_85 S2.
   }
   assert (S4 : (φ x <[- x -]> (x = B))
@@ -2341,7 +2270,6 @@ Proof.
       ↔ (P -> [ι φ | ιφ => χ ιφ]))).
   {
     (* simplification *)
-    clear S2.
     intro Hp.
     pose proof (S1 Hp) as S1.
     pose proof (S3 Hp) as S3.
@@ -2386,7 +2314,6 @@ Proof.
     intro Hp.
     pose proof (S2 Hp) as S2.
     pose proof (n4_84 ([ι φ | ιφ => χ ιφ]) (χ B) P) as n4_85.
-    clear S1.
     now MP n4_85 S2.
   }
   assert (S4 : (φ x <[- x -]> (x = B))
@@ -2394,7 +2321,6 @@ Proof.
       ↔ ([ι φ | ιφ => χ ιφ] -> P))).
   {
     (* simplification *)
-    clear S2.
     intro Hp.
     pose proof (S1 Hp) as S1.
     pose proof (S3 Hp) as S3.
@@ -2443,7 +2369,6 @@ Proof.
     intro Hp.
     pose proof (S2 Hp) as S2.
     pose proof (n4_86 ([ι φ | ιφ => χ ιφ]) (χ B) P) as n4_86.
-    clear S1.
     setoid_rewrite -> n4_21 in n4_86 at 3.
     setoid_rewrite -> n4_21 in n4_86 at 4.
     now MP n4_86 S2.
@@ -2453,7 +2378,6 @@ Proof.
       ↔ (P ↔ [ι φ | ιφ => χ ιφ]))).
   {
     (* simplification *)
-    clear S2.
     intro Hp.
     pose proof (S1 Hp) as S1.
     pose proof (S3 Hp) as S3.

--- a/pm/ch14.v
+++ b/pm/ch14.v
@@ -302,7 +302,7 @@ Proof.
       (φ X) (φ X) (X = B) (X = B)) as n4_38.
     rewrite <- n4_24 in n4_38.
     pose proof (n10_1 (fun x => (φ x ↔ x = B)) X) as n10_1.
-    Syll n10_1 n4_38 Sa.
+    Syll_as n10_1 n4_38 Sa.
     pose proof (n11_11 X X (fun z w => 
       (∀ x : Prop, φ x ↔ x = B) →
       (φ z ∧ φ w ↔ z = B ∧ w = B))) as n11_11.
@@ -320,7 +320,7 @@ Proof.
     pose proof (S2 x y) as S2.
     destruct S2 as [S2l _].
     pose proof (n13_172 B x y) as n13_172.
-    now Syll S2l n13_172 S3.
+    now Syll_as S2l n13_172 S3.
   }
   assert (S4 : (∃ b, (φ x <[- x -]> (x = b)))
     → ((φ x ∧ φ y) -[ x y ]> (x = y))).
@@ -331,7 +331,7 @@ Proof.
     now rewrite -> n10_23 in n10_11.
   }
   assert (S5 : [ιE φ] → ((φ x ∧ φ y) -[ x y ]> (x = y))).
-  { now Syll S1 S4 S5. }
+  { now Syll_as S1 S4 S5. }
   exact S5.
 Qed.
 
@@ -344,7 +344,7 @@ Proof.
   {
     pose proof (n10_1 (fun x => φ x ↔ (x = B)) B) as n10_1a.
     pose proof (n10_1 (fun x => φ x ↔ (x = C)) B) as n10_1b.
-    Conj n10_1a n10_1b C1.
+    Conj_as n10_1a n10_1b C1.
     pose proof (n3_47
       (φ x <[- x -]> x = B) (φ x <[- x -]> x = C)
       (φ B ↔ (B = B)) (φ B ↔ (B = C))) as n3_47.
@@ -369,7 +369,7 @@ Proof.
     assert (S2_1 : φ B ∧ (φ B → B = C)).
     { 
       clear S1.
-      now Conj A1 A2l S2_1. 
+      now Conj_as A1 A2l S2_1. 
     }
     pose proof (Ass3_35 (φ B) (B = C)) as Ass3_35.
     now MP Ass3_35 S2_1.
@@ -417,7 +417,7 @@ Proof.
   {
     pose proof (n10_281 φ (fun x => φ x ∧ x = B)) 
       as n10_281.
-    now Syll S4 n10_281 S5.
+    now Syll_as S4 n10_281 S5.
   }
   assert (S6 : (φ x -[ x ]> (x = B)) → ((∃ x, 
     φ x) ↔ φ B)).
@@ -433,7 +433,7 @@ Proof.
       ↔ ((φ x -[ x ]> (x = B)) ∧ ∃ x, φ x))).
   {
     clear S1 S3 S4 S5 S6.
-    now Conj S2 S7 S8.
+    now Conj_as S2 S7 S8.
   }
   exact S8.
 Qed.
@@ -493,7 +493,7 @@ Proof.
   {
     pose proof (n11_341 φ (fun z w => 
       φ z w ∧ (z = X) ∧ (w = Y))) as n11_341.
-    now Syll n11_341 S4 S5.
+    now Syll_as n11_341 S4 S5.
   }
   assert (S6 : (φ z w -[ z w ]> ((z = X) ∧ (w = Y)))
     → ((∃ z w, φ z w) ↔ φ X Y)).
@@ -512,7 +512,7 @@ Proof.
       ↔ ((φ z w -[ z w ]> (z = X ∧ w = Y)) ∧ ∃ z w, φ z w))).
   {
     clear S1 S3 S4 S5 S6.
-    now Conj S2 S7 S8.
+    now Conj_as S2 S7 S8.
   }
   exact S8.
 Qed.
@@ -539,7 +539,7 @@ Proof.
     pose proof (Simp3_27
       (φ z w -[ z w ]> z = X ∧ w = Y)
       (φ X Y)) as Simp3_27.
-    Syll n14_123l Simp3_27 Sy1.
+    Syll_as n14_123l Simp3_27 Sy1.
     pose proof (n11_11 X Y (fun x y =>
       (φ z w <[- z w -]> z = x ∧ w = y) → φ x y)) as n11_11.
     MP n11_11 Sy1.
@@ -560,7 +560,7 @@ Proof.
     destruct n11_1b as [n11_1bl _].
     MP n11_1a Hp.
     destruct n11_1a as [n11_1al _].
-    Conj n11_1al n11_1bl C1.
+    Conj_as n11_1al n11_1bl C1.
     pose proof (n3_47 (φ Z W) (φ U V)
       (Z = X ∧ W = Y) (U = X ∧ V = Y)) as n3_47.
     MP n3_47 C1.
@@ -582,10 +582,10 @@ Proof.
       (Z = X ∧ U = X) (W = Y ∧ V = Y)
       (Z = U) (W = V)) as n3_47.
     assert (C1 : (Z = X ∧ U = X → Z = U) ∧ (W = Y ∧ V = Y → W = V)).
-    { clear n3_47; now Conj n13_172a n13_172b C1. }
+    { clear n3_47; now Conj_as n13_172a n13_172b C1. }
     MP n3_47 C1.
     (* simplification for syll *)
-    now Syll S2 n3_47 S3.
+    now Syll_as S2 n3_47 S3.
   }
   assert (S4 : (∃ x y, φ z w <[- z w -]> ((z = x) ∧ (w = y)))
     → (((φ Z W) ∧ (φ U V)) → ((Z = U) ∧ (W = V)))).
@@ -688,7 +688,7 @@ Proof.
     assert (C1 : ((∃ x y,  φ z w <[- z w -]> z = x ∧ w = y) → ∃ x y : Prop, φ x y)
       ∧ ((∃ x y,  φ z w <[- z w -]> z = x ∧ w = y)
         → (φ z w ∧ φ u v) -[ z w u v ]> (z = u ∧ w = v))).
-    { clear S9. now Conj S1 S5 C1. }
+    { clear S9. now Conj_as S1 S5 C1. }
     pose proof (Comp3_43
       (∃ x y, φ z w <[- z w -]> z = x ∧ w = y)
       (∃ x y, φ x y)
@@ -697,7 +697,7 @@ Proof.
     MP Comp3_43 C1.
     clear S1 S5 C1.
     move S9 after Comp3_43.
-    Conj Comp3_43 S9 S10.
+    Conj_as Comp3_43 S9 S10.
     now Equiv S10.
   }
   exact S10.
@@ -845,7 +845,7 @@ Proof.
     pose proof (n14_1 φ (fun c =>
       [ι ψ | ιψ => c = ιψ])) as n14_1b.
     destruct n14_1b as [n14_1bl _].
-    Conj n14_1al n14_1bl C1.
+    Conj_as n14_1al n14_1bl C1.
     pose proof (n3_47
       ([ι φ | ιφ => A = ιφ])
       ([ι φ | ιφ => [ι ψ | ιψ => ιφ = ιψ]])
@@ -920,7 +920,7 @@ Proof.
       ∧ ([ι2 ψ, χ | ιψ ιχ => ιψ = ιχ]
       → ∃ b c, (ψ x <[- x -]> x = b)
           ∧ (χ x <[- x -]> x = c) ∧ b = c)).
-    { now Conj n14_113al n14_113bl C1. }
+    { now Conj_as n14_113al n14_113bl C1. }
     pose proof (n3_47
       ([ι2 φ, ψ | ιφ ιψ => ιφ = ιψ])
       ([ι2 ψ, χ | ιψ ιχ => ιψ = ιχ])
@@ -952,7 +952,7 @@ Proof.
     setoid_rewrite -> n13_195 in S1r.
     setoid_rewrite -> n4_3 in S1r.
     clear Hp.
-    now Conj S1l S1r C1.
+    now Conj_as S1l S1r C1.
   }
   assert (S3 : ([ι2 φ, ψ | ιφ ιψ => ιφ = ιψ]
       ∧ [ι2 ψ, χ | ιψ ιχ => ιψ = ιχ])
@@ -1037,7 +1037,7 @@ Proof.
     pose proof (n14_1 ψ (fun x => A = x)) as n14_1.
     assert (C1 : ([ι φ | ιφ => A = ιφ] ↔ φ x <[- x -]> x = A)
       ∧ ([ι ψ | ιψ => A = ιψ] ↔ ∃ b, (ψ x <[- x -]> x = b) ∧ A = b)).
-    { clear S1. now Conj S2 n14_1 C1. }
+    { clear S1. now Conj_as S2 n14_1 C1. }
     pose proof (n4_38
       ([ι φ | ιφ => A = ιφ])
       ([ι ψ | ιψ => A = ιψ])
@@ -1055,7 +1055,7 @@ Proof.
     destruct S4 as [S4 _].
     pose proof (n10_24 (fun a => ∃ b, (φ x <[- x -]> x = a) 
       ∧ (ψ x <[- x -]> x = b) ∧ a = b) A) as n10_24.
-    Syll n10_24 S4 S4_1.
+    Syll_as n10_24 S4 S4_1.
     now rewrite <- n14_112 in S4_1.
   }
   exact S5.
@@ -1138,7 +1138,7 @@ Proof.
         → [ι φ | ιφ => χ ιφ] ↔ χ B)
       ∧ ([ι ψ | ιψ => B = ιψ]
         → χ B ↔ [ι ψ | ιψ => χ ιψ])).
-    { clear S1 S2. now Conj S3 S4 C1. }
+    { clear S1 S2. now Conj_as S3 S4 C1. }
     pose proof (n3_47
       (φ x <[- x -]> x = B)
       ([ι ψ | ιψ => B = ιψ])
@@ -1147,7 +1147,7 @@ Proof.
     MP n3_47 C1.
     pose proof (n4_22 ([ι φ | ιφ => χ ιφ]) (χ B)
       ([ι ψ | ιψ => χ ιψ])) as n4_22.
-    now Syll n3_47 n4_22 S5.
+    now Syll_as n3_47 n4_22 S5.
   }
   assert (S6 : [ι φ | ιφ => [ι ψ | ιψ => ιφ = ιψ]]
     → ([ι φ | ιφ => χ ιφ] ↔ [ι ψ | ιψ => χ ιψ])).
@@ -1159,7 +1159,7 @@ Proof.
       as n10_11.
     MP n10_11 S5.
     rewrite -> n10_23 in n10_11.
-    now Syll S1 n10_11 S6.
+    now Syll_as S1 n10_11 S6.
   }
   exact S6.
 Qed.
@@ -1198,7 +1198,7 @@ Proof.
     assert (C1 : ((∀ x, Iχ x ↔ x = B) → Iχ B ↔ B = B)
       ∧ ((∀ x : Order 1, [ι φ | ιφ => x ιφ] ↔ x B)
         → [ι φ | ιφ => Iχ ιφ] ↔ Iχ B)).
-    { now Conj n10_1a n10_1b C1. }
+    { now Conj_as n10_1a n10_1b C1. }
     pose proof (n3_47
       (∀ x, Iχ x ↔ x = B)
       (∀ x : Order 1, [ι φ | ιφ => x ιφ] ↔ x B)
@@ -1209,7 +1209,7 @@ Proof.
       (B = B)) as n4_22.
     clear n10_1a n10_1b C1.
     rewrite -> n4_3 in n4_22.
-    Syll n3_47 n4_22 Sy1.
+    Syll_as n3_47 n4_22 Sy1.
     (* We can see that in the original text, `Iχ` has been substituted into
     a concrete function. Our analogue here is generalizing over this "Individual"
     whose body is currently an "admitted" definition to further substitute into
@@ -1217,12 +1217,12 @@ Proof.
     pose proof (n10_11_pred Iχ (fun p => 
       [ι φ | ιφ => p ιφ] ↔ B = B)) as n10_11a.
     clear n3_47 n4_22.
-    Syll Sy1 n10_11a Sy2.
+    Syll_as Sy1 n10_11a Sy2.
     pose proof (n10_1_pred
       (fun p => [ι φ | ιφ => p ιφ] ↔ B = B)
       (fun x => x = B)) as n10_1c.
     clear Sy1 n10_11a.
-    now Syll Sy2 n10_1c S2.
+    now Syll_as Sy2 n10_1c S2.
   }
   assert (S3 : ((Iχ x <[- x -]> (x = B)) 
       ∧ (∀ ψ : Order 1, [ι φ | ιφ => ψ ιφ]
@@ -1265,7 +1265,7 @@ Proof.
         → ∀ ψ : Order 1, [ι φ | ιφ => ψ ιφ]↔ ψ B)
       ∧ ((∀ ψ : Order 1, [ι φ | ιφ => ψ ιφ] ↔ ψ B)
         → [ι φ | ιφ => ιφ = B])).
-    { clear S2 S3 S4 S5. now Conj S1 S6 C1. }
+    { clear S2 S3 S4 S5. now Conj_as S1 S6 C1. }
     now Equiv C1.
   }
   exact S7.
@@ -1299,7 +1299,7 @@ Proof.
     ↔ (∀ ψ : Order 1, ψ B → [ι φ | ιφ => ψ ιφ])).
   {
     clear S2.
-    Conj S1 S3 C1.
+    Conj_as S1 S3 C1.
     now Equiv C1.
   }
   exact S4.
@@ -1446,9 +1446,9 @@ Proof.
     }
     assert (C1 : ([ι φ | ιφ => ιφ = B] ↔ (φ x <[- x -]> B = x))
       ∧ ((φ x <[- x -]> B = x) ↔ [ι φ | ιφ => B = ιφ])).
-    { clear S3_1. now Conj S3_2 S3_3 C1. }
+    { clear S3_1. now Conj_as S3_2 S3_3 C1. }
     clear S2 S3_2 S3_3.
-    now Conj S3_1 C1 S3.
+    now Conj_as S3_1 C1 S3.
   }
   exact S3.
 Qed.
@@ -1465,7 +1465,7 @@ Proof.
   {
     pose proof (n14_201 φ) as n14_201.
     pose proof (n14_12 φ) as n14_12.
-    Conj n14_201 n14_12 C1.
+    Conj_as n14_201 n14_12 C1.
     now rewrite -> n4_76 in C1.
   }
   assert (S2 : (φ B ∧ ((φ x ∧ φ y) -[ x y ]> (x = y)))
@@ -1490,7 +1490,7 @@ Proof.
     pose proof (n10_1 (fun x => ((φ x ∧ φ B) -> (x = B)) ∧ φ B) X) as n10_1.
     rewrite -> n10_33 in n10_1.
     rewrite -> n4_3 in n10_1.
-    Syll S2 n10_1 Sy1.
+    Syll_as S2 n10_1 Sy1.
     setoid_rewrite -> n4_3 in Sy1 at 3.
     setoid_rewrite -> n4_3 in Sy1 at 4.
     setoid_rewrite <- n5_33 in Sy1.
@@ -1500,7 +1500,7 @@ Proof.
     MP Fact3_45 n10_11.
     rewrite -> n4_3 in Fact3_45.
     setoid_rewrite -> n4_3 in Fact3_45 at 2.
-    now Syll Sy1 Fact3_45 S3.
+    now Syll_as Sy1 Fact3_45 S3.
   }
   assert (S4 : (φ B ∧ ((φ x ∧ φ y) -[ x y ]> (x = y)))
     -> (((x = B) -[ x ]> φ x) ∧ (φ x -[ x ]> (x = B)))).
@@ -1547,7 +1547,7 @@ Proof.
     ↔ ((∃ x, φ x) ∧ ((φ x ∧ φ y)) -[ x y ]> (x = y))).
   {
     clear S2 S3 S4 S5 S6 S7.
-    Conj S1 S8 S9.
+    Conj_as S1 S8 S9.
     now Equiv S9.
   }
   exact S9.
@@ -1680,7 +1680,7 @@ Proof.
     ↔ [ι (fun x => φ x ∧ ψ x) | ι1 => φ ι1]).
   {
     clear S1. 
-    now Syll S2 S3 S4.
+    now Syll_as S2 S3 S4.
   }
   exact S4.
 Qed.
@@ -1792,7 +1792,7 @@ Proof.
   destruct n14_202 as [n14_202l _].
   destruct n14_202l as [n14_202ll _].
   pose proof (n14_15 B φ ψ) as n14_15.
-  Syll n14_202ll n14_15 S1.
+  Syll_as n14_202ll n14_15 S1.
   now rewrite -> n4_21 in S1.
 Qed.
 
@@ -1816,7 +1816,7 @@ Proof.
     MP n10_27 n10_11.
     pose proof (n10_271 (fun z => φ z → ψ z)
       (fun z => z = B → ψ z)) as n10_271.
-    now Syll n10_27 n10_271 S1.
+    now Syll_as n10_27 n10_271 S1.
   }
   assert (S2 : (φ x <[- x -]> (x = B)) -> ((φ x -[ x ]> ψ x)
     ↔ ψ B)).
@@ -1862,7 +1862,7 @@ Proof.
   {
     pose proof (n10_281 (fun x => φ x ∧ ψ x)
       (fun x => (x = B) ∧ ψ x)) as n10_281.
-    now Syll S2 n10_281 S3.
+    now Syll_as S2 n10_281 S3.
   }
   assert (S4 : (φ x <[- x -]> (x = B))
     -> ((∃ x, φ x ∧ ψ x) ↔ ψ B)).
@@ -1898,7 +1898,7 @@ Proof.
     pose proof (n14_25 φ ψ) as n14_25.
     MP n14_25 Hp.
     rewrite -> n4_21 in n14_25.
-    now Conj S1 n14_25 S7.
+    now Conj_as S1 n14_25 S7.
   }
   exact S7.
 Qed.
@@ -1936,7 +1936,7 @@ Proof.
   {
     pose proof (n10_271 (fun x => φ x ↔ ψ x)
       (fun x => ψ x ↔ (x = B))) as n10_271.
-    now Syll S2 n10_271 S3.
+    now Syll_as S2 n10_271 S3.
   }
   assert (S4 : (φ x <[- x -]> (x = B))
     -> ((φ x <[- x -]> ψ x) ↔ [ι ψ | ιψ => B = ιψ])).
@@ -1970,7 +1970,7 @@ Proof.
     rewrite -> n10_23 in n10_11.
     pose proof (n14_11 φ) as n14_11.
     destruct n14_11 as [n14_11l _].
-    now Syll n14_11l n10_11 S6.
+    now Syll_as n14_11l n10_11 S6.
   }
   exact S6.
 Qed.
@@ -2018,7 +2018,7 @@ Proof.
   {
     pose proof (n10_281 (fun b => φ x <[- x -]> (x = b))
       (fun b => ψ x <[- x -]> (x = b))) as n10_281.
-    now Syll n10_281 S4 S5.
+    now Syll_as n10_281 S4 S5.
   }
   assert (S6 : (φ x <[- x -]> ψ x) → ([ιE φ] ↔ [ιE ψ])).
   { now repeat rewrite <- n14_02 in S5. }
@@ -2064,7 +2064,7 @@ Proof.
       (φ x <[- x -]> x = B) (χ B)) as Fact3_45b.
     MP Fact3_45b S2r.
     clear S1 S2l S2r Hp.
-    Conj Fact3_45a Fact3_45b S3.
+    Conj_as Fact3_45a Fact3_45b S3.
     now Equiv S3.
   }
   assert (S4 : (φ x <[- x -]> ψ x) 
@@ -2083,7 +2083,7 @@ Proof.
   {
     pose proof (n10_281 (fun b => (φ x <[- x -]> x = b) ∧ χ b)
       (fun b => (ψ x <[- x -]> x = b) ∧ χ b)) as n10_281.
-    now Syll S4 n10_281 S5.
+    now Syll_as S4 n10_281 S5.
   }
   assert (S6 : (φ x <[- x -]> ψ x)
     → [ι φ | ιφ => χ ιφ] ↔ [ι ψ | ιψ => χ ιψ]).
@@ -2216,7 +2216,7 @@ Proof.
     -> ((P ∨ [ι φ | ιφ => χ ιφ]) ↔ (P ∨ χ B))).
   {
     pose proof (n4_37 ([ι φ | ιφ => χ ιφ]) (χ B) P) as n4_37.
-    Syll S2 n4_37 S3.
+    Syll_as S2 n4_37 S3.
     setoid_rewrite -> n4_31 in S3 at 1.
     now setoid_rewrite -> n4_31 in S3 at 2.
   }
@@ -2299,7 +2299,7 @@ Proof.
     ↔ ¬ [ι φ | ιφ => χ ιφ])).
   {
     clear S1 S2 S3 S4.
-    Conj S5 S6 S7.
+    Conj_as S5 S6 S7.
     now Equiv S7.
   }
   exact S7.

--- a/pm/ch2.v
+++ b/pm/ch2.v
@@ -147,11 +147,29 @@ Proof.
   exact Syll2_05d.
 Qed.
 
-Ltac Syll H1 H2 S :=
-  let S := fresh S in lazymatch goal with 
-    | [ H1 : ?P → ?Q, H2 : ?Q → ?R |- _ ] =>
-       assert (S : P → R) by (intros p; exact (H2 (H1 p)));
-       simpl in S
+(* To be tested and used in the future: syllogism in-place*)
+Ltac Syll H1 H2 :=
+  let S := fresh in
+  lazymatch goal with 
+  | [ _H1 : ?P → ?Q, _H2 : ?Q → ?R |- _ ] =>
+    constr_eq H1 _H1;
+    constr_eq H2 _H2;
+    assert (S : P → R) by (intros p; exact (H2 (H1 p)));
+    pose proof S as H1;
+    simpl in H1;
+    clear S
+  end.
+
+(* We won't use `Syll` theorem but just to perform it as efficient as possible,
+  knowing that it has been already proven *)
+Ltac Syll_as H1 H2 S :=
+  let S := fresh S in
+    lazymatch goal with 
+    | [ _H1 : ?P → ?Q, _H2 : ?Q → ?R |- _ ] =>
+      constr_eq H1 _H1;
+      constr_eq H2 _H2;
+      assert (S : P → R) by (intros p; exact (H2 (H1 p)));
+      simpl in S
   end.
 
 Theorem Transp2_16 (P Q : Prop) :
@@ -161,7 +179,7 @@ Proof.
   pose proof (Syll2_05 P Q (¬¬ Q)) as Syll2_05a.
   pose proof (Transp2_03 P (¬ Q)) as Transp2_03a.
   MP Syll2_05a n2_12a.
-  Syll Syll2_05a Transp2_03a S.
+  Syll_as Syll2_05a Transp2_03a S.
   exact S.
 Qed.
 
@@ -172,7 +190,7 @@ Proof.
   pose proof (n2_14 Q) as n2_14a.
   pose proof (Syll2_05 P (¬¬ Q) Q) as Syll2_05a.
   MP Syll2_05a n2_14a.
-  Syll Transp2_03a Syll2_05a S.
+  Syll_as Transp2_03a Syll2_05a S.
   exact S.
 Qed.
 
@@ -184,9 +202,9 @@ Proof.
   pose proof Syll2_05 as Syll2_05.
   MP Syll2_05a n2_12a.
   pose proof (Abs2_01 (¬ P)) as Abs2_01a.
-  Syll Syll2_05a Abs2_01a Sa.
+  Syll_as Syll2_05a Abs2_01a Sa.
   pose proof (n2_14 P) as n2_14a.
-  Syll H n2_14a Sb.
+  Syll_as Sa n2_14a Sb.
   exact Sb.
 Qed.
 
@@ -195,7 +213,7 @@ Theorem n2_2 (P Q : Prop) :
 Proof.
   pose proof (Add1_3 Q P) as Add1_3a.
   pose proof (Perm1_4 Q P) as Perm1_4a.
-  Syll Add1_3a Perm1_4a S.
+  Syll_as Add1_3a Perm1_4a S.
   exact S.
 Qed.
 
@@ -261,8 +279,8 @@ Proof.
   pose proof (n2_3 P Q R) as n2_3a.
   pose proof (Assoc1_5 P R Q) as Assoc1_5a.
   pose proof (Perm1_4 R (P ∨ Q)) as Perm1_4a.
-  Syll Assoc1_5a Perm1_4a Sa.
-  Syll n2_3a Sa Sb.
+  Syll_as Assoc1_5a Perm1_4a Sa.
+  Syll_as n2_3a Sa Sb.
   exact Sb.
 Qed.
 
@@ -308,7 +326,7 @@ Proof.
   pose proof (Syll2_05 (P ∨ Q) (P ∨ R) (R ∨ P)) as Syll2_05a.
   MP Syll2_05a Perm1_4a.
   pose proof (Sum1_6 P Q R) as Sum1_6a.
-  Syll Sum1_6a Syll2_05a S.
+  Syll_as Sum1_6a Syll2_05a S.
   exact S.
 Qed.
 
@@ -319,7 +337,7 @@ Proof.
   pose proof (Syll2_06 (Q ∨ P) (P ∨ Q) (P ∨ R)) as Syll2_06a.
   MP Syll2_06a Perm1_4a.
   pose proof (Sum1_6 P Q R) as Sum1_6a.
-  Syll Sum1_6a Syll2_06a S.
+  Syll_as Sum1_6a Syll2_06a S.
   exact S.
 Qed.
 
@@ -332,9 +350,9 @@ Proof.
   pose proof (Perm1_4 Q P) as Perm1_4b.
   pose proof (Syll2_06 (Q ∨ P) (P ∨ Q) (P ∨ R)) as Syll2_06a.
   MP Syll2_06a Perm1_4b.
-  Syll Syll2_06a Syll2_05a H.
+  Syll_as Syll2_06a Syll2_05a H.
   pose proof (Sum1_6 P Q R) as Sum1_6a.
-  Syll Sum1_6a H S.
+  Syll_as Sum1_6a H S.
   exact S.
 Qed.
 
@@ -345,7 +363,7 @@ Proof.
   pose proof (Taut1_2 P) as Taut1_2a.
   pose proof (n2_38 Q (P ∨ P) P) as n2_38a.
   MP n2_38a Taut1_2a.
-  Syll n2_31a n2_38a S.
+  Syll_as n2_31a n2_38a S.
   exact S.
 Qed.
 
@@ -356,7 +374,7 @@ Proof.
   pose proof (Taut1_2 Q) as Taut1_2a.
   pose proof (Sum1_6 P (Q ∨ Q) Q) as Sum1_6a.
   MP Sum1_6a Taut1_2a.
-  Syll Assoc1_5a Sum1_6a S.
+  Syll_as Assoc1_5a Sum1_6a S.
   exact S.
 Qed.
 
@@ -401,7 +419,7 @@ Theorem n2_47 (P Q : Prop) :
 Proof.
   pose proof (n2_45 P Q) as n2_45a.
   pose proof (n2_2 (¬ P) Q) as n2_2a.
-  Syll n2_45a n2_2a S.
+  Syll_as n2_45a n2_2a S.
   exact S.
 Qed.
 
@@ -410,7 +428,7 @@ Theorem n2_48 (P Q : Prop) :
 Proof.
   pose proof (n2_46 P Q) as n2_46a.
   pose proof (Add1_3 P (¬ Q)) as Add1_3a.
-  Syll n2_46a Add1_3a S.
+  Syll_as n2_46a Add1_3a S.
   exact S.
 Qed.
 
@@ -419,7 +437,7 @@ Theorem n2_49 (P Q : Prop) :
 Proof.
   pose proof (n2_45 P Q) as n2_45a.
   pose proof (n2_2 (¬ P) (¬ Q)) as n2_2a.
-  Syll n2_45a n2_2a S.
+  Syll_as n2_45a n2_2a S.
   exact S.
 Qed.
 
@@ -458,7 +476,7 @@ Theorem n2_521 (P Q : Prop) :
 Proof.
   pose proof (n2_52 P Q) as n2_52a.
   pose proof (Transp2_17 Q P) as Transp2_17a.
-  Syll n2_52a Transp2_17a S.
+  Syll_as n2_52a Transp2_17a S.
   exact S.
 Qed.
 
@@ -500,7 +518,7 @@ Proof.
   pose proof (Perm1_4 P Q) as Perm1_4a.
   pose proof (Syll2_06 (P ∨ Q) (Q ∨ P) P) as Syll2_06a.
   MP Syll2_06a Perm1_4a.
-  Syll n2_55a Syll2_06a Sa.
+  Syll_as n2_55a Syll2_06a Sa.
   exact Sa.
 Qed.
 
@@ -511,7 +529,7 @@ Proof.
   pose proof (Taut1_2 Q) as Taut1_2a.
   pose proof (Syll2_05 (¬ P ∨ Q) (Q ∨ Q) Q) as Syll2_05a.
   MP Syll2_05a Taut1_2a.
-  Syll n2_38a Syll2_05a S.
+  Syll_as n2_38a Syll2_05a S.
   replace (¬ P ∨ Q) with (P → Q) in S
     by now rewrite Impl1_01.
   exact S.
@@ -531,7 +549,7 @@ Theorem n2_62 (P Q : Prop) :
 Proof.
   pose proof (n2_53 P Q) as n2_53a.
   pose proof (n2_6 P Q) as n2_6a.
-  Syll n2_53a n2_6a S.
+  Syll_as n2_53a n2_6a S.
   exact S.
 Qed.
 
@@ -558,11 +576,11 @@ Theorem n2_64 (P Q : Prop) :
 Proof.
   pose proof (n2_63 Q P) as n2_63a.
   pose proof (Perm1_4 P Q) as Perm1_4a.
-  Syll n2_63a Perm1_4a Ha.
+  Syll_as Perm1_4a n2_63a Ha.
   pose proof (Syll2_06 (P ∨ ¬ Q) (¬ Q ∨ P) P) as Syll2_06a.
   pose proof (Perm1_4 P (¬ Q)) as Perm1_4b.
   MP Syll2_06a Perm1_4b.
-  Syll Syll2_06a Ha S.
+  Syll_as Ha Syll2_06a S.
   exact S.
 Qed.
 
@@ -585,7 +603,7 @@ Proof.
   pose proof (n2_24  P Q) as n2_24.
   pose proof (Syll2_06 P (¬ P → Q) Q) as Syll2_06b.
   MP Syll2_06b n2_24.
-  Syll Syll2_06b Syll2_06a S.
+  Syll_as Syll2_06a Syll2_06b S.
   exact S.
 Qed.
 
@@ -596,7 +614,7 @@ Proof.
   replace (¬ P ∨ Q) with (P → Q) in n2_67a
     by now rewrite Impl1_01.
   pose proof (n2_54 P Q) as n2_54a.
-  Syll n2_67a n2_54a S.
+  Syll_as n2_67a n2_54a S.
   exact S.
 Qed.
 
@@ -605,9 +623,9 @@ Theorem n2_69 (P Q : Prop) :
 Proof.
   pose proof (n2_68 P Q) as n2_68a.
   pose proof (Perm1_4 P Q) as Perm1_4a.
-  Syll n2_68a Perm1_4a Sa.
+  Syll_as n2_68a Perm1_4a Sa.
   pose proof (n2_62 Q P) as n2_62a.
-  Syll Sa n2_62a Sb.
+  Syll_as Sa n2_62a Sb.
   exact Sb.
 Qed.
 
@@ -616,7 +634,7 @@ Theorem n2_73 (P Q R : Prop) :
 Proof.
   pose proof (n2_621 P Q) as n2_621a.
   pose proof (n2_38 R (P ∨ Q) Q) as n2_38a.
-  Syll n2_621a n2_38a S.
+  Syll_as n2_621a n2_38a S.
   exact S.
 Qed.
 
@@ -626,12 +644,12 @@ Proof.
   pose proof (n2_73 Q P R) as n2_73a.
   pose proof (Assoc1_5 P Q R) as Assoc1_5a.
   pose proof (n2_31 Q P R) as n2_31a. (*not cited*)
-  Syll Assoc1_5a n2_31a Sa.
+  Syll_as Assoc1_5a n2_31a Sa.
   pose proof (n2_32 P Q R) as n2_32a. (*not cited*)
-  Syll n2_32a Sa Sb.
+  Syll_as n2_32a Sa Sb.
   pose proof (Syll2_06 ((P ∨ Q) ∨ R) ((Q ∨ P) ∨ R) (P ∨ R)) as Syll2_06a.
   MP Syll2_06a Sb.
-  Syll n2_73a Syll2_05a H.
+  Syll_as n2_73a Syll2_06a H.
   exact H.
 Qed.
 
@@ -640,13 +658,13 @@ Theorem n2_75 (P Q R : Prop) :
 Proof.
   pose proof (n2_74 P (¬ Q) R) as n2_74a.
   pose proof (n2_53 Q P) as n2_53a.
-  Syll n2_53a n2_74a Sa.
+  Syll_as n2_53a n2_74a Sa.
   pose proof (n2_31 P (¬ Q) R) as n2_31a.
   pose proof (Syll2_06 (P ∨ (¬ Q) ∨ R) ((P ∨ (¬ Q)) ∨ R) (P ∨ R)) as Syll2_06a.
   MP Syll2_06a n2_31a.
-  Syll Sa Syll2_06a Sb.
+  Syll_as Sa Syll2_06a Sb.
   pose proof (Perm1_4 P Q) as Perm1_4a. (*not cited*)
-  Syll Perm1_4a Sb Sc.
+  Syll_as Perm1_4a Sb Sc.
   replace (¬ Q ∨ R) with (Q → R) in Sc
     by now rewrite Impl1_01.
   exact Sc.
@@ -677,9 +695,9 @@ Theorem n2_8 (Q R S : Prop) :
 Proof.
   pose proof (n2_53 R Q) as n2_53a.
   pose proof (Perm1_4 Q R) as Perm1_4a.
-  Syll Perm1_4a n2_53a Ha.
+  Syll_as Perm1_4a n2_53a Ha.
   pose proof (n2_38 S (¬ R) Q) as n2_38a.
-  Syll H n2_38a Hb.
+  Syll_as Ha n2_38a Hb.
   exact Hb.
 Qed.
 
@@ -690,7 +708,7 @@ Proof.
   pose proof (n2_76 P R S) as n2_76a.
   pose proof (Syll2_05 (P ∨ Q) (P ∨ (R → S)) ((P ∨ R) → (P ∨ S))) as Syll2_05a.
   MP Syll2_05a n2_76a.
-  Syll Sum1_6a Syll2_05a H.
+  Syll_as Sum1_6a Syll2_05a H.
   exact H.
 Qed.
 
@@ -725,17 +743,17 @@ Proof.
   MP Syll2_06a Add1_3a.
   pose proof (n2_55 P R) as n2_55a.
   pose proof (Syll2_05 (P ∨ Q) (P ∨ R) R) as Syll2_05a.
-  Syll n2_55a Syll2_05a Ha.
+  Syll_as n2_55a Syll2_05a Ha.
   pose proof (n2_83 (¬ P) ((P ∨ Q) → (P ∨ R)) ((P ∨ Q) → R) (Q → R)) as n2_83a.
   MP n2_83a Ha.
   pose proof (Comm2_04 (¬ P) (P ∨ Q → P ∨ R) (Q → R)) as Comm2_04a.
-  Syll Ha Comm2_04a Hb.
+  Syll_as n2_83a Comm2_04a Hb.
   pose proof (n2_54 P (Q → R)) as n2_54a.
   pose proof (Simp2_02 (¬ P) ((P ∨ Q → R) → (Q → R))) as Simp2_02a. (*Not cited*)
   (*Greg's suggestion per the BRS list on June 25, 2017.*)
   MP Simp2_02a Syll2_06a.
   MP Hb Simp2_02a.
-  Syll Hb n2_54a Hc.
+  Syll_as Hb n2_54a Hc.
   exact Hc.
 Qed.
 

--- a/pm/ch2.v
+++ b/pm/ch2.v
@@ -733,7 +733,7 @@ Proof.
   pose proof (n2_54 P (Q → R)) as n2_54a.
   pose proof (Simp2_02 (¬ P) ((P ∨ Q → R) → (Q → R))) as Simp2_02a. (*Not cited*)
   (*Greg's suggestion per the BRS list on June 25, 2017.*)
-  MP Syll2_06a Simp2_02a.
+  MP Simp2_02a Syll2_06a.
   MP Hb Simp2_02a.
   Syll Hb n2_54a Hc.
   exact Hc.

--- a/pm/ch2.v
+++ b/pm/ch2.v
@@ -44,7 +44,7 @@ Proof.
 Qed.
 
 Theorem Syll2_05 (P Q R : Prop) :
-  (Q → R) → ((P  → Q) → (P → R)).
+  (Q → R) → ((P → Q) → (P → R)).
 Proof.
   pose proof (Sum1_6 (¬ P) Q R) as Sum1_6.
   replace (¬ P ∨ Q) with (P → Q) in Sum1_6.
@@ -156,7 +156,6 @@ Ltac Syll H1 H2 :=
     constr_eq H2 _H2;
     assert (S : P → R) by (intros p; exact (H2 (H1 p)));
     pose proof S as H1;
-    simpl in H1;
     clear S
   end.
 
@@ -168,8 +167,7 @@ Ltac Syll_as H1 H2 S :=
     | [ _H1 : ?P → ?Q, _H2 : ?Q → ?R |- _ ] =>
       constr_eq H1 _H1;
       constr_eq H2 _H2;
-      assert (S : P → R) by (intros p; exact (H2 (H1 p)));
-      simpl in S
+      assert (S : P → R) by (intros p; exact (H2 (H1 p)))
   end.
 
 Theorem Transp2_16 (P Q : Prop) :

--- a/pm/ch2.v
+++ b/pm/ch2.v
@@ -150,7 +150,7 @@ Qed.
 (* To be tested and used in the future: syllogism in-place*)
 Ltac Syll H1 H2 :=
   let S := fresh in
-  lazymatch goal with 
+  match goal with 
   | [ _H1 : ?P → ?Q, _H2 : ?Q → ?R |- _ ] =>
     constr_eq H1 _H1;
     constr_eq H2 _H2;
@@ -163,7 +163,7 @@ Ltac Syll H1 H2 :=
   knowing that it has been already proven *)
 Ltac Syll_as H1 H2 S :=
   let S := fresh S in
-    lazymatch goal with 
+    match goal with 
     | [ _H1 : ?P → ?Q, _H2 : ?Q → ?R |- _ ] =>
       constr_eq H1 _H1;
       constr_eq H2 _H2;

--- a/pm/ch2.v
+++ b/pm/ch2.v
@@ -160,7 +160,7 @@ Proof.
   pose proof (n2_12 Q) as n2_12a.
   pose proof (Syll2_05 P Q (¬¬ Q)) as Syll2_05a.
   pose proof (Transp2_03 P (¬ Q)) as Transp2_03a.
-  MP n2_12a Syll2_05a.
+  MP Syll2_05a n2_12a.
   Syll Syll2_05a Transp2_03a S.
   exact S.
 Qed.
@@ -171,7 +171,7 @@ Proof.
   pose proof (Transp2_03 (¬ Q) P) as Transp2_03a.
   pose proof (n2_14 Q) as n2_14a.
   pose proof (Syll2_05 P (¬¬ Q) Q) as Syll2_05a.
-  MP n2_14a Syll2_05a.
+  MP Syll2_05a n2_14a.
   Syll Transp2_03a Syll2_05a S.
   exact S.
 Qed.
@@ -181,7 +181,8 @@ Theorem n2_18 (P : Prop) :
 Proof.
   pose proof (n2_12 P) as n2_12a.
   pose proof (Syll2_05 (¬ P) P (¬¬ P)) as Syll2_05a.
-  MP Syll2_05a n2_12.
+  pose proof Syll2_05 as Syll2_05.
+  MP Syll2_05a n2_12a.
   pose proof (Abs2_01 (¬ P)) as Abs2_01a.
   Syll Syll2_05a Abs2_01a Sa.
   pose proof (n2_14 P) as n2_14a.
@@ -382,7 +383,7 @@ Theorem n2_45 (P Q : Prop) :
 Proof.
   pose proof (n2_2 P Q) as n2_2a.
   pose proof (Transp2_16 P (P ∨ Q)) as Transp2_16a.
-  MP n2_2 Transp2_16a.
+  MP Transp2_16a n2_2a.
   exact Transp2_16a.
 Qed.
 
@@ -391,7 +392,7 @@ Theorem n2_46 (P Q : Prop) :
 Proof.
   pose proof (Add1_3 P Q) as Add1_3a.
   pose proof (Transp2_16 Q (P ∨ Q)) as Transp2_16a.
-  MP Add1_3a Transp2_16a.
+  MP Transp2_16a Add1_3a.
   exact Transp2_16a.
 Qed.
 
@@ -477,7 +478,7 @@ Theorem n2_54 (P Q : Prop) :
 Proof.
   pose proof (n2_14 P) as n2_14a.
   pose proof (n2_38 Q (¬¬ P) P) as n2_38a.
-  MP n2_38a n2_12a.
+  MP n2_38a n2_14a.
   replace (¬¬ P ∨ Q) with (¬ P → Q) in n2_38a
     by now rewrite Impl1_01.
   exact n2_38a.
@@ -488,7 +489,7 @@ Theorem n2_55 (P Q : Prop) :
 Proof.
   pose proof (n2_53 P Q) as n2_53a.
   pose proof (Comm2_04 (P ∨ Q) (¬ P) Q) as Comm2_04a.
-  MP n2_53a Comm2_04a.
+  MP Comm2_04a n2_53a.
   exact Comm2_04a.
 Qed.
 
@@ -583,7 +584,7 @@ Proof.
   MP Syll2_06a n2_54a.
   pose proof (n2_24  P Q) as n2_24.
   pose proof (Syll2_06 P (¬ P → Q) Q) as Syll2_06b.
-  MP Syll2_06b n2_24a.
+  MP Syll2_06b n2_24.
   Syll Syll2_06b Syll2_06a S.
   exact S.
 Qed.

--- a/pm/ch3.v
+++ b/pm/ch3.v
@@ -44,14 +44,24 @@ Qed.
 
 (*3.03 is permits the inference from the theoremhood 
     of P and that of Q to the theoremhood of P and Q. So: *)
-Ltac Conj H1 H2 C :=
+(* This version of Conj rewrites `H1` into the result *)
+Ltac Conj H1 H2 :=
+  let C := fresh in
   match goal with 
     | [ _H1 : ?P, _H2 : ?Q |- _ ] =>
       constr_eq H1 _H1;
       constr_eq H2 _H2;
-      pose proof (Conj3_03 P Q) as C;
-      MP C H1; 
-      MP C H2
+      assert (C : P /\ Q) by (split; [apply H1 | apply H2]);
+      pose proof C as H1;
+      clear C
+  end.
+
+Ltac Conj_as H1 H2 C :=
+  match goal with 
+    | [ _H1 : ?P, _H2 : ?Q |- _ ] =>
+      constr_eq H1 _H1;
+      constr_eq H2 _H2;
+      assert (C : P /\ Q) by (split; [apply H1 | apply H2])
   end.
 
 Theorem n3_1 (P Q : Prop) :
@@ -97,7 +107,7 @@ Proof.
   pose proof (Transp2_16 (P ∧ Q) (¬ (¬ P ∨ ¬ Q))) as Transp2_16a.
   MP Transp2_16a n3_1a.
   pose proof (n2_12 (¬ P ∨ ¬ Q)) as n2_12a.
-  Syll n2_12a Transp2_16a S.
+  Syll_as n2_12a Transp2_16a S.
   exact S.
 Qed.
 
@@ -127,9 +137,9 @@ Theorem n3_22 (P Q : Prop) :
 Proof.
   pose proof (n3_13 Q P) as n3_13a.
   pose proof (Perm1_4 (¬ Q) (¬ P)) as Perm1_4a.
-  Syll n3_13a Perm1_4a Ha.
+  Syll_as n3_13a Perm1_4a Ha.
   pose proof (n3_14  P Q) as n3_14a.
-  Syll Ha n3_14a Hb.
+  Syll_as Ha n3_14a Hb.
   pose proof (Transp2_17 (P ∧ Q) (Q ∧ P)) as Transp2_17a.
   MP Transp2_17a Hb.
   exact Transp2_17a.
@@ -165,7 +175,7 @@ Theorem Simp3_27 (P Q : Prop) :
 Proof.
   pose proof (n3_22 P Q) as n3_22a.
   pose proof (Simp3_26 Q P) as Simp3_26a.
-  Syll n3_22a Simp3_26a S.
+  Syll_as n3_22a Simp3_26a S.
   exact S.
 Qed.
 
@@ -177,17 +187,17 @@ Proof.
     (((P ∧ Q) → R) → (¬ (¬ P ∨ ¬ Q) → R)) in Id2_08a
     by now rewrite Prod3_01.
   pose proof (Transp2_15 (¬ P ∨ ¬ Q) R) as Transp2_15a.
-  Syll Id2_08a Transp2_15a Sa.
+  Syll_as Id2_08a Transp2_15a Sa.
   pose proof (Id2_08 (¬ R → (¬ P ∨ ¬ Q))) as Id2_08b. (*This theorem isn't needed.*)
-  Syll Sa Id2_08b Sb.
+  Syll_as Sa Id2_08b Sb.
   replace (¬ P ∨ ¬ Q) with (P → ¬ Q) in Sb
     by now rewrite Impl1_01.
   pose proof (Comm2_04 (¬ R) P (¬ Q)) as Comm2_04a.
-  Syll Sb Comm2_04a Sc.
+  Syll_as Sb Comm2_04a Sc.
   pose proof (Transp2_17 Q R) as Transp2_17a.
   pose proof (Syll2_05 P (¬ R → ¬ Q) (Q → R)) as Syll2_05a.
   MP Syll2_05a Transp2_17a.
-  Syll Sa Syll2_05a Sd.
+  Syll_as Sc Syll2_05a Sd.
   exact Sd.
 Qed.
 
@@ -202,11 +212,11 @@ Proof.
     (¬ P ∨ (¬ Q ∨ R)) in Id2_08a
     by now rewrite Impl1_01.
   pose proof (n2_31 (¬ P) (¬ Q) R) as n2_31a.
-  Syll Id2_08a n2_31a Sa.
+  Syll_as Id2_08a n2_31a Sa.
   pose proof (n2_53 (¬ P ∨ ¬ Q) R) as n2_53a.
   replace (¬ (¬ P ∨ ¬ Q)) with (P ∧ Q) in n2_53a
     by now rewrite Prod3_01.
-  Syll Sa n2_53a Sb.
+  Syll_as Sa n2_53a Sb.
   exact Sb.
 Qed.
 
@@ -244,9 +254,9 @@ Proof.
   pose proof (Syll2_05 P (Q → R) (¬ R → ¬ Q)) as Syll2_05a.
   MP Syll2_05a Transp2_16a.
   pose proof (Exp3_3 P Q R) as Exp3_3a.
-  Syll Exp3_3a Syll2_05a Sa.
+  Syll_as Exp3_3a Syll2_05a Sa.
   pose proof (Imp3_31 P (¬ R) (¬ Q)) as Imp3_31a.
-  Syll Sa Imp3_31a Sb.
+  Syll_as Sa Imp3_31a Sb.
   exact Sb.
 Qed.
 
@@ -288,7 +298,7 @@ Proof.
   pose proof (Syll2_05 P Q (R → Q ∧ R)) as Syll2_05a.
   MP Syll2_05a n3_2a.
   pose proof (n2_77 P R (Q ∧ R)) as n2_77a.
-  Syll Syll2_05a n2_77a Sa.
+  Syll_as Syll2_05a n2_77a Sa.
   pose proof (Imp3_31 (P → Q) (P → R) (P → Q ∧ R)) as Imp3_31a.
   MP Imp3_31a Sa.
   exact Imp3_31a.
@@ -299,19 +309,19 @@ Theorem n3_44 (P Q R : Prop) :
 Proof.
   pose proof (Syll3_33 (¬ Q) R P) as Syll3_33a.
   pose proof (n2_6 Q P) as n2_6a.
-  Syll Syll3_33a n2_6a Sa.
+  Syll_as Syll3_33a n2_6a Sa.
   pose proof (Exp3_3 (¬ Q → R) (R → P) ((Q → P) → P)) as Exp3_3a.
   MP Exp3_3a Sa.
   pose proof (Comm2_04 (R → P) (Q → P) P) as Comm2_04a.
-  Syll Exp3_3a Comm2_04a Sb.
+  Syll_as Exp3_3a Comm2_04a Sb.
   pose proof (Imp3_31 (Q → P) (R → P) P) as Imp3_31a.
-  Syll Sb Imp3_31a Sc.
+  Syll_as Sb Imp3_31a Sc.
   pose proof (Comm2_04 (¬ Q → R) ((Q → P) ∧ (R → P)) P) as Comm2_04b.
   MP Comm2_04b Sc.
   pose proof (n2_53 Q R) as n2_53a.
   pose proof (Syll2_06 (Q ∨ R) (¬ Q → R) P) as Syll2_06a.
   MP Syll2_06a n2_53a.
-  Syll Comm2_04b Syll2_06a Sd.
+  Syll_as Comm2_04b Syll2_06a Sd.
   exact Sd.
 Qed.
 
@@ -320,9 +330,9 @@ Theorem Fact3_45 (P Q R : Prop) :
 Proof.
   pose proof (Syll2_06 P Q (¬ R)) as Syll2_06a.
   pose proof (Transp2_16 (Q → ¬ R) (P → ¬ R)) as Transp2_16a.
-  Syll Syll2_06a Transp2_16a Sa.
-  pose proof (Id2_08 (¬ (P → R) → ¬ (Q → ¬ R))) as Id2_08a.
-  Syll Sa Id2_08a Sb.
+  Syll_as Syll2_06a Transp2_16a Sa.
+  pose proof (Id2_08 (¬ (P → ¬ R) → ¬ (Q → ¬ R))) as Id2_08a.
+  Syll_as Sa Id2_08a Sb.
   replace (P → ¬ R) with (¬ P ∨ ¬ R) in Sb
     by now rewrite Impl1_01.
   replace (Q → ¬ R) with (¬ Q ∨ ¬ R) in Sb
@@ -341,7 +351,7 @@ Proof.
   {
     pose proof (Simp3_26 (P → R) (Q → S)) as Simp3_26a.
     pose proof (Fact3_45 P R Q) as Fact3_45a.
-    Syll Simp3_26a Fact3_45a Sa_1.
+    Syll_as Simp3_26a Fact3_45a Sa_1.
     exact Sa_1.
   }
   assert (Sb : (P → R) ∧ (Q → S) → P ∧ Q → Q ∧ R).
@@ -349,14 +359,14 @@ Proof.
     pose proof (n3_22 R Q) as n3_22a.
     pose proof (Syll2_05 (P ∧ Q) (R ∧ Q) (Q ∧ R)) as Syll2_05a.
     MP Syll2_05a n3_22a.
-    Syll Sa Syll2_05a Sb_1.
+    Syll_as Sa Syll2_05a Sb_1.
     exact Sb_1.
   }
   assert (Sc : (P → R) ∧ (Q → S) → Q ∧ R → S ∧ R).
   {
     pose proof (Simp3_27 (P → R) (Q → S)) as Simp3_27a.
     pose proof (Fact3_45 Q S R) as Fact3_45b.
-    Syll Simp3_27a Fact3_45b Sc_1.
+    Syll_as Simp3_27a Fact3_45b Sc_1.
     exact Sc_1.
   }
   assert (Sd : (P → R) ∧ (Q → S) → Q ∧ R → R ∧ S).
@@ -364,7 +374,7 @@ Proof.
     pose proof (n3_22 S R) as n3_22b.
     pose proof (Syll2_05 (Q ∧ R) (S ∧ R) (R ∧ S)) as Syll2_05b.
     MP Syll2_05b n3_22b.
-    Syll Sc Syll2_05b Sd_1.
+    Syll_as Sc Syll2_05b Sd_1.
     exact Sd_1.
   }
   pose proof (n2_83 ((P → R) ∧ (Q → S)) (P ∧ Q) (Q ∧ R) (R ∧ S)) as n2_83a. (*This with MP works, but it omits Conj3_03.*)
@@ -372,7 +382,7 @@ Proof.
     (((P → R) ∧ (Q → S)) → ((Q ∧ R) → (R ∧ S))) 
     (((P → R) ∧ (Q → S)) → ((P ∧ Q) → (R ∧ S)))) as Imp3_31a.
   MP Imp3_31a n2_83a.
-  Conj Sb Sd C.
+  Conj_as Sb Sd C.
   MP Imp3_31a C.
   exact Imp3_31a.
 Qed.
@@ -382,18 +392,18 @@ Theorem n3_48 (P Q R S : Prop) :
 Proof.
   pose proof (Simp3_26 (P → R) (Q → S)) as Simp3_26a.
   pose proof (Sum1_6 Q P R) as Sum1_6a.
-  Syll Simp3_26a Sum1_6a Sa.
+  Syll_as Simp3_26a Sum1_6a Sa.
   pose proof (Perm1_4 P Q) as Perm1_4a.
   pose proof (Syll2_06 (P ∨ Q) (Q ∨ P) (Q ∨ R)) as Syll2_06a.
   MP Syll2_06a Perm1_4a.
-  Syll Sa Syll2_06a Sb.
+  Syll_as Sa Syll2_06a Sb.
   pose proof (Simp3_27 (P → R) (Q → S)) as Simp3_27a.
   pose proof (Sum1_6 R Q S) as Sum1_6b.
-  Syll Simp3_27a Sum1_6b Sc.
+  Syll_as Simp3_27a Sum1_6b Sc.
   pose proof (Perm1_4 Q R) as Perm1_4b.
   pose proof (Syll2_06 (Q ∨ R) (R ∨ Q) (R ∨ S)) as Syll2_06b.
   MP Syll2_06b Perm1_4b.
-  Syll Sc Syll2_06a Sd.
+  Syll_as Sc Syll2_06b Sd.
   pose proof (n2_83 ((P → R) ∧ (Q → S)) (P ∨ Q) (Q ∨ R) (R ∨ S)) as n2_83a.
   MP n2_83a Sb.
   MP n2_83a Sd.

--- a/pm/ch3.v
+++ b/pm/ch3.v
@@ -44,16 +44,14 @@ Qed.
 
 (*3.03 is permits the inference from the theoremhood 
     of P and that of Q to the theoremhood of P and Q. So: *)
-Ltac Conj_test H1 H2 C :=
+Ltac Conj H1 H2 C :=
   match goal with 
-    | [ _H1 : ?P |- _ ] =>
+    | [ _H1 : ?P, _H2 : ?Q |- _ ] =>
       constr_eq H1 _H1;
-      match goal with 
-      | [ _H2 : ?Q |- _ ] =>
-        constr_eq H2 _H2;
-        pose proof (Conj3_03 P Q) as C;
-        pose proof (C H1 H2) as C
-      end
+      constr_eq H2 _H2;
+      pose proof (Conj3_03 P Q) as C;
+      MP C H1; 
+      MP C H2
   end.
 
 Theorem n3_1 (P Q : Prop) :
@@ -374,7 +372,7 @@ Proof.
     (((P → R) ∧ (Q → S)) → ((Q ∧ R) → (R ∧ S))) 
     (((P → R) ∧ (Q → S)) → ((P ∧ Q) → (R ∧ S)))) as Imp3_31a.
   MP Imp3_31a n2_83a.
-  Conj_test Sb Sd C.
+  Conj Sb Sd C.
   MP Imp3_31a C.
   exact Imp3_31a.
 Qed.

--- a/pm/ch3.v
+++ b/pm/ch3.v
@@ -41,23 +41,20 @@ Proof.
   exact n2_32a.
   all: now rewrite Impl1_01.
 Qed.
-(*3.03 is permits the inference from the theoremhood 
-    of P and that of Q to the theoremhood of P and Q.So:*)
 
-(* NOTE:
-Although this Ltac simplifies the proof a lot, there is only one safe way
-to perform the `Conj`. We have to 
-1. `assert` the final proposition being produced
-2. `clear` all irrevalent hypotheses
-3. `move` the only two hypotheses into right order, optionally
-4. `Conj` them and `exact` the result
-*)
-Ltac Conj H1 H2 C :=
-  let C := fresh C in lazymatch goal with 
-    | [ H1 : ?P, H2 : ?Q |- _ ] =>  
-      (pose proof (Conj3_03 P Q) as C; simpl in C;
-      MP Conj3_03 P; MP Conj3_03 Q)
-end.
+(*3.03 is permits the inference from the theoremhood 
+    of P and that of Q to the theoremhood of P and Q. So: *)
+Ltac Conj_test H1 H2 C :=
+  match goal with 
+    | [ _H1 : ?P |- _ ] =>
+      constr_eq H1 _H1;
+      match goal with 
+      | [ _H2 : ?Q |- _ ] =>
+        constr_eq H2 _H2;
+        pose proof (Conj3_03 P Q) as C;
+        pose proof (C H1 H2) as C
+      end
+  end.
 
 Theorem n3_1 (P Q : Prop) :
   (P ∧ Q) → ¬ (¬ P ∨ ¬ Q).
@@ -111,7 +108,7 @@ Theorem n3_2 (P Q : Prop) :
 Proof.
   pose proof (n3_12 P Q) as n3_12a.
   pose proof (n2_32 (¬ P) (¬ Q) (P ∧ Q)) as n2_32a.
-  MP n3_32a n3_12a.
+  MP n2_32a n3_12a.
   replace (¬ Q ∨ P ∧ Q) with (Q → P ∧ Q) in n2_32a.
   replace (¬ P ∨ (Q → P ∧ Q)) with (P → Q → P ∧ Q) in n2_32a.
   exact n2_32a.
@@ -158,7 +155,7 @@ Proof.
   pose proof (n2_31 (¬ P) (¬ Q) P) as n2_31a.
   MP n2_31a Simp2_02a.
   pose proof (n2_53 (¬ P ∨ ¬ Q) P) as n2_53a.
-  MP n2_53a Simp2_02a.
+  MP n2_53a n2_31a.
   replace (¬ (¬ P ∨ ¬ Q)) with (P ∧ Q) in n2_53a
     by now rewrite Prod3_01.
   exact n2_53a.
@@ -273,7 +270,7 @@ Theorem n3_41 (P Q R : Prop) :
 Proof.
   pose proof (Simp3_26 P Q) as Simp3_26a.
   pose proof (Syll2_06 (P ∧ Q) P R) as Syll2_06a.
-  MP Simp3_26a Syll2_06a.
+  MP Syll2_06a Simp3_26a.
   exact Syll2_06a.
 Qed.
 
@@ -295,7 +292,7 @@ Proof.
   pose proof (n2_77 P R (Q ∧ R)) as n2_77a.
   Syll Syll2_05a n2_77a Sa.
   pose proof (Imp3_31 (P → Q) (P → R) (P → Q ∧ R)) as Imp3_31a.
-  MP Sa Imp3_31a.
+  MP Imp3_31a Sa.
   exact Imp3_31a.
 Qed.
 
@@ -372,13 +369,12 @@ Proof.
     Syll Sc Syll2_05b Sd_1.
     exact Sd_1.
   }
-  clear Sa Sc.
-  Conj Sb Sd C.
   pose proof (n2_83 ((P → R) ∧ (Q → S)) (P ∧ Q) (Q ∧ R) (R ∧ S)) as n2_83a. (*This with MP works, but it omits Conj3_03.*)
   pose proof (Imp3_31 (((P → R) ∧ (Q → S)) → ((P ∧ Q) → (Q ∧ R)))
     (((P → R) ∧ (Q → S)) → ((Q ∧ R) → (R ∧ S))) 
     (((P → R) ∧ (Q → S)) → ((P ∧ Q) → (R ∧ S)))) as Imp3_31a.
   MP Imp3_31a n2_83a.
+  Conj_test Sb Sd C.
   MP Imp3_31a C.
   exact Imp3_31a.
 Qed.

--- a/pm/ch4.v
+++ b/pm/ch4.v
@@ -36,7 +36,7 @@ Theorem Transp4_1 (P Q : Prop) :
 Proof.
   pose proof (Transp2_16 P Q) as Transp2_16a.
   pose proof (Transp2_17 P Q) as Transp2_17a.
-  Conj Transp2_16a Transp2_17a C.
+  Conj_as Transp2_16a Transp2_17a C.
   Equiv C.
   exact C.
 Qed.
@@ -48,11 +48,11 @@ Proof.
   {
     pose proof (Transp2_16 P Q) as Transp2_16a.
     pose proof (Transp2_16 Q P) as Transp2_16b.
-    Conj Transp2_16a Transp2_16b Ca.
+    Conj_as Transp2_16a Transp2_16b Ca.
     pose proof (n3_47 (P → Q) (Q → P) (¬ Q → ¬ P) (¬ P → ¬ Q)) as n3_47a.
     MP n3_47 Ca.
     pose proof (n3_22 (¬ Q → ¬ P) (¬ P → ¬ Q)) as n3_22a.
-    Syll n3_47a n3_22a Sa_1.
+    Syll_as n3_47a n3_22a Sa_1.
     exact Sa_1.
   }
   replace ((P → Q) ∧ (Q → P)) with (P ↔ Q) in Sa.
@@ -61,16 +61,16 @@ Proof.
   {
     pose proof (Transp2_17 Q P) as Transp2_17a.
     pose proof (Transp2_17 P Q) as Transp2_17b.
-    Conj Transp2_17a Transp2_17b Cb.
+    Conj_as Transp2_17a Transp2_17b Cb.
     pose proof (n3_47 (¬ P → ¬ Q) (¬ Q → ¬ P) (Q → P) (P → Q)) as n3_47a.
     MP n3_47a Cb.
     pose proof (n3_22 (Q → P) (P → Q)) as n3_22a.
-    Syll n3_47a n3_22a Sb_1.
+    Syll_as n3_47a n3_22a Sb_1.
     exact Sb_1.
   }
   replace ((P → Q) ∧ (Q → P)) with (P ↔ Q) in Sb.
   replace ((¬ P → ¬ Q) ∧ (¬ Q → ¬ P)) with (¬ P ↔ ¬ Q) in Sb.
-  Conj Sa Sb Cc.
+  Conj_as Sa Sb Cc.
   Equiv Cc.
   exact Cc.
   all: now rewrite Equiv4_01.
@@ -83,7 +83,7 @@ Proof.
   {
     pose proof (Transp2_03 P Q) as Transp2_03a.
     pose proof (Transp2_15 Q P) as Transp2_15a.
-    Conj Transp2_03a Transp2_15a Ca.
+    Conj_as Transp2_03a Transp2_15a Ca.
     exact Ca.
   }
   pose proof (n3_47 (P → ¬ Q) (¬ Q → P) (Q → ¬ P) (¬ P → Q)) as n3_47a.
@@ -92,13 +92,13 @@ Proof.
   {
     pose proof (Transp2_03 Q P) as Transp2_03b.
     pose proof (Transp2_15 P Q) as Transp2_15b.
-    Conj Transp2_03b Transp2_15b Cb.
+    Conj_as Transp2_03b Transp2_15b Cb.
     exact Cb.
   }
   pose proof (n3_47 (Q → ¬ P) (¬ P → Q) (P → ¬ Q) (¬ Q → P)) as n3_47b.
   MP n3_47b Ca.
   clear Ca Cb.
-  Conj n3_47a n3_47b Cc.
+  Conj_as n3_47a n3_47b Cc.
   rewrite <- Equiv4_01 in Cc.
   rewrite <- Equiv4_01 in Cc.
   rewrite <- Equiv4_01 in Cc.
@@ -110,7 +110,7 @@ Theorem n4_13 (P : Prop) :
 Proof.
   pose proof (n2_12 P) as n2_12a.
   pose proof (n2_14 P) as n2_14a.
-  Conj n2_12a n2_14a C.
+  Conj_as n2_12a n2_14a C.
   Equiv C.
   exact C.
 Qed.
@@ -120,7 +120,7 @@ Theorem n4_14 (P Q R : Prop) :
 Proof.
   pose proof (Transp3_37 P Q R) as Transp3_37a.
   pose proof (Transp3_37 P (¬ R) (¬ Q)) as Transp3_37b.
-  Conj Transp3_37a Transp3_37b C.
+  Conj_as Transp3_37a Transp3_37b C.
   pose proof (n4_13 Q) as n4_13a.
   apply propositional_extensionality in n4_13a.
   pose proof (n4_13 R) as n4_13b.
@@ -155,7 +155,7 @@ Proof.
     pose proof (Simp3_26 ((Q ∧ P → ¬ R) → Q ∧ R → ¬ P) 
         ((Q ∧ R → ¬ P) → Q ∧ P → ¬ R)) as Simp3_26a.
     MP Simp3_26a n4_14a.
-    Syll Syll2_06a Simp3_26a Sa.
+    Syll_as Syll2_06a Simp3_26a Sa.
     exact Sa.
   }
   assert (Sb : (Q ∧ R → ¬ P) → P ∧ Q → ¬ R).
@@ -166,10 +166,10 @@ Proof.
     pose proof (n3_22 P Q) as n3_22b.
     pose proof (Syll2_06 (P ∧ Q) (Q ∧ P) (¬ R)) as Syll2_06b.
     MP Syll2_06b n3_22b.
-    Syll Syll2_06b Simp3_27a Sb.
+    Syll_as Syll2_06b Simp3_27a Sb.
     exact Sb.
   }
-  Conj Sa Sb C.
+  Conj_as Sa Sb C.
   Equiv C.
   exact C.
 Qed.
@@ -198,7 +198,7 @@ Proof.
     in n3_22b.
   replace ((Q → P) ∧ (P → Q)) with (Q ↔ P) 
     in n3_22b.
-  Conj n3_22a n3_22b C.
+  Conj_as n3_22a n3_22b C.
   Equiv C.
   exact C.
   all: now rewrite Equiv4_01.
@@ -212,7 +212,7 @@ Proof.
     pose proof (Simp3_26 (P → Q) (Q → P)) as Simp3_26b.
     replace ((P → Q) ∧ (Q → P)) with (P ↔ Q) 
       in Simp3_26b by now rewrite Equiv4_01.
-    Syll Simp3_26a Simp3_26b Sa.
+    Syll_as Simp3_26a Simp3_26b Sa.
     exact Sa.
   }
   assert (Sb : (P ↔ Q) ∧ (Q ↔ R) → Q → R). {
@@ -220,7 +220,7 @@ Proof.
     pose proof (Simp3_26 (Q → R) (R → Q)) as Simp3_26c.
     replace ((Q → R) ∧ (R → Q)) with (Q ↔ R) 
       in Simp3_26c by now rewrite Equiv4_01.
-    Syll Simp3_27a Simp3_26c Sb.
+    Syll_as Simp3_27a Simp3_26c Sb.
     exact Sb.
   }
   pose proof (n2_83 ((P ↔ Q) ∧ (Q ↔ R)) P Q R) as n2_83a.
@@ -232,7 +232,7 @@ Proof.
     pose proof (Simp3_27 (Q → R) (R → Q)) as Simp3_27c.
     replace ((Q → R) ∧ (R → Q)) with (Q ↔ R) 
       in Simp3_27c by now rewrite Equiv4_01.
-    Syll Simp3_27b Simp3_27c Sc.
+    Syll_as Simp3_27b Simp3_27c Sc.
     exact Sc.
   }
   assert (Sd : (P ↔ Q) ∧ (Q ↔ R) → Q → P).
@@ -241,14 +241,14 @@ Proof.
     pose proof (Simp3_27 (P → Q) (Q → P)) as Simp3_27d.
     replace ((P → Q) ∧ (Q → P)) with (P ↔ Q) 
       in Simp3_27d by now rewrite Equiv4_01.
-    Syll Simp3_26d Simp3_27d Sd.
+    Syll_as Simp3_26d Simp3_27d Sd.
     exact Sd.
   }
   pose proof (n2_83 ((P ↔ Q) ∧ (Q ↔ R)) R Q P) as n2_83b.
   MP n2_83b Sc.
   MP n2_83b Sd.
   clear Sa Sb Sc Sd.
-  Conj n2_83a n2_83b C.
+  Conj_as n2_83a n2_83b C.
   pose proof (Comp3_43 ((P ↔ Q) ∧ (Q ↔ R)) (P → R) (R → P)) as Comp3_43a.
   MP Comp3_43a C.
   replace ((P → R) ∧ (R → P)) with (P ↔ R) 
@@ -263,7 +263,7 @@ Proof.
   pose proof (n2_43 P (P ∧ P)) as n2_43a.
   MP n3_2a n2_43a.
   pose proof (Simp3_26 P P) as Simp3_26a.
-  Conj n2_43a Simp3_26a C.
+  Conj_as n2_43a Simp3_26a C.
   Equiv C.
   exact C.
 Qed.
@@ -273,7 +273,7 @@ Theorem n4_25 (P : Prop) :
 Proof.
   pose proof (Add1_3 P P) as Add1_3a.
   pose proof (Taut1_2 P) as Taut1_2a.
-  Conj Add1_3a Taut1_2a C.
+  Conj_as Add1_3a Taut1_2a C.
   Equiv C.
   exact C.
 Qed.
@@ -283,7 +283,7 @@ Theorem n4_3 (P Q : Prop) :
 Proof.
   pose proof (n3_22 P Q) as n3_22a.
   pose proof (n3_22 Q P) as n3_22b.
-  Conj n3_22a n3_22b C.
+  Conj_as n3_22a n3_22b C.
   Equiv C.
   exact C.
 Qed.
@@ -293,7 +293,7 @@ Theorem n4_31 (P Q : Prop) :
 Proof.
   pose proof (Perm1_4 P Q) as Perm1_4a.
   pose proof (Perm1_4 Q P) as Perm1_4b.
-  Conj Perm1_4a Perm1_4b C.
+  Conj_as Perm1_4a Perm1_4b C.
   Equiv C.
   exact C.
 Qed.
@@ -346,7 +346,7 @@ Theorem n4_33 (P Q R : Prop) :
 Proof.
   pose proof (n2_31 P Q R) as n2_31a.
   pose proof (n2_32 P Q R) as n2_32a.
-  Conj n2_31a n2_32a C.
+  Conj_as n2_31a n2_32a C.
   Equiv C.
   exact C.
 Qed.
@@ -374,7 +374,7 @@ Theorem n4_36 (P Q R : Prop) :
 Proof.
   pose proof (Fact3_45 P Q R) as Fact3_45a.
   pose proof (Fact3_45 Q P R) as Fact3_45b.
-  Conj Fact3_45a Fact3_45b C.
+  Conj_as Fact3_45a Fact3_45b C.
   pose proof (n3_47 (P → Q) (Q → P) 
       (P ∧ R → Q ∧ R) (Q ∧ R → P ∧ R)) as n3_47a.
   MP n3_47 C.
@@ -389,7 +389,7 @@ Theorem n4_37 (P Q R : Prop) :
 Proof.
   pose proof (Sum1_6 R P Q) as Sum1_6a.
   pose proof (Sum1_6 R Q P) as Sum1_6b.
-  Conj Sum1_6a Sum1_6b C.
+  Conj_as Sum1_6a Sum1_6b C.
   pose proof (n3_47 (P → Q) (Q → P) 
       (R ∨ P → R ∨ Q) (R ∨ Q → R ∨ P)) as n3_47a.
   MP n3_47 C.
@@ -412,7 +412,7 @@ Theorem n4_38 (P Q R S : Prop) :
 Proof.
   pose proof (n3_47 P Q R S) as n3_47a.
   pose proof (n3_47 R S P Q) as n3_47b.
-  Conj n3_47a n3_47b Ca.
+  Conj_as n3_47a n3_47b Ca.
   pose proof (n3_47 ((P → R) ∧ (Q → S)) 
       ((R → P) ∧ (S → Q)) (P ∧ Q → R ∧ S) (R ∧ S → P ∧ Q)) as n3_47c.
   MP n3_47c Ca.
@@ -429,7 +429,7 @@ Proof.
       by now apply n4_32b.
   pose proof (n3_22 (Q → S) (R → P)) as n3_22a.
   pose proof (n3_22 (R → P) (Q → S)) as n3_22b.
-  Conj n3_22a n3_22b Cb.
+  Conj_as n3_22a n3_22b Cb.
   Equiv Cb.
   pose proof (n4_3 (R → P) (Q → S)) as n4_3a.
   apply propositional_extensionality in n4_3a.
@@ -459,7 +459,7 @@ Theorem n4_39 (P Q R S : Prop) :
 Proof.
   pose proof (n3_48 P Q R S) as n3_48a.
   pose proof (n3_48 R S P Q) as n3_48b.
-  Conj n3_48a n3_48b Ca.
+  Conj_as n3_48a n3_48b Ca.
   pose proof (n3_47 ((P → R) ∧ (Q → S)) 
       ((R → P) ∧ (S → Q)) (P ∨ Q → R ∨ S) (R ∨ S → P ∨ Q)) as n3_47a.
   MP n3_47a Ca.
@@ -477,7 +477,7 @@ Proof.
       by now apply n4_32b.
   pose proof (n3_22 (Q → S) (R → P)) as n3_22a.
   pose proof (n3_22 (R → P) (Q → S)) as n3_22b.
-  Conj  n3_22a n3_22b Cb.
+  Conj_as  n3_22a n3_22b Cb.
   Equiv Cb.
   apply propositional_extensionality in Cb.
   symmetry in Cb.
@@ -508,20 +508,20 @@ Proof.
   {
     pose proof (n3_2 P Q) as n3_2a.
     pose proof (n3_2 P R) as n3_2b.
-    Conj n3_2a n3_2b Ca.
+    Conj_as n3_2a n3_2b Ca.
     exact Ca.
   }
   pose proof (Comp3_43 P (Q → P ∧ Q) (R → P ∧ R)) as Comp3_43a.
   MP Comp3_43a Ca.
   pose proof (n3_48 Q R (P ∧ Q) (P ∧ R)) as n3_48a.
-  Syll Comp3_43a n3_48a Sa.
+  Syll_as Comp3_43a n3_48a Sa.
   pose proof (Imp3_31 P (Q ∨ R) ((P ∧ Q) ∨ (P ∧ R))) as Imp3_31a.
   MP Imp3_31a Sa.
   assert (Cb: (P ∧ Q → P) ∧ (P ∧ R → P)).
   {
     pose proof (Simp3_26 P Q) as Simp3_26a.
     pose proof (Simp3_26 P R) as Simp3_26b.
-    Conj Simp3_26a Simp3_26b Cb.
+    Conj_as Simp3_26a Simp3_26b Cb.
     exact Cb.
   }
   pose proof (n3_44 P (P ∧ Q) (P ∧ R)) as n3_44a.
@@ -530,17 +530,17 @@ Proof.
   {
     pose proof (Simp3_27 P Q) as Simp3_27a.
     pose proof (Simp3_27 P R) as Simp3_27b.
-    Conj Simp3_27a Simp3_27b Cc.
+    Conj_as Simp3_27a Simp3_27b Cc.
     exact Cc.
   }
   pose proof (n3_48 (P ∧ Q) (P ∧ R) Q R) as n3_48b.
   MP n3_48b Cc.
   clear Ca Cb Cc Comp3_43a Sa.
-  Conj n3_44a n3_48b Cdd. (*Cd is reserved*)
+  Conj_as n3_44a n3_48b Cdd. (*Cd is reserved*)
   pose proof (Comp3_43 (P ∧ Q ∨ P ∧ R) P (Q ∨ R)) as Comp3_43b.
   MP Comp3_43b Cdd.
   clear n3_48a n3_44a n3_48b Cdd.
-  Conj Imp3_31a Comp3_43b Ce.
+  Conj_as Imp3_31a Comp3_43b Ce.
   Equiv Ce.
   exact Ce.
 Qed.
@@ -563,22 +563,22 @@ Proof.
     exact Sum1_6b.
   }
   (* ??? *)
-  Conj Sum1_6a Sum1_6b Ca.
+  Conj_as Sum1_6a Sum1_6b Ca.
   pose proof (Comp3_43 (P ∨ Q ∧ R) (P ∨ Q) (P ∨ R)) as Comp3_43a.
   MP Comp3_43a Ca.
   pose proof (n2_53 P Q) as n2_53a.
   pose proof (n2_53 P R) as n2_53b.
-  Conj n2_53a n2_53b Cb.
+  Conj_as n2_53a n2_53b Cb.
   pose proof (n3_47 (P ∨ Q) (P ∨ R) (¬ P → Q) (¬ P → R)) as n3_47a.
   MP n3_47a Cb.
   pose proof (Comp3_43 (¬ P) Q R) as Comp3_43b.
-  Syll n3_47a Comp3_43b Sa.
+  Syll_as n3_47a Comp3_43b Sa.
   pose proof (n2_54 P (Q ∧ R)) as n2_54a.
-  Syll Sa n2_54a Sb.
+  Syll_as Sa n2_54a Sb.
   clear Sum1_6a. clear Sum1_6b. clear Ca. clear n2_53a.
       clear n2_53b. clear Cb. clear n3_47a. clear Sa.
       clear Comp3_43b. clear n2_54a.
-  Conj Comp3_43a Sb Cc.
+  Conj_as Comp3_43a Sb Cc.
   Equiv Cc.
   exact Cc.
 Qed.
@@ -590,7 +590,7 @@ Proof.
   pose proof (n2_11 Q) as n2_11a.
   MP n3_21a n2_11a.
   pose proof (Simp3_26 P (Q ∨ ¬ Q)) as Simp3_26a. clear n2_11a.
-  Conj n3_21a Simp3_26a C.
+  Conj_as n3_21a Simp3_26a C.
   Equiv C.
   pose proof (n4_4 P Q (¬ Q)) as n4_4a.
   apply propositional_extensionality in C.
@@ -604,12 +604,12 @@ Theorem n4_43 (P Q : Prop) :
 Proof.
   pose proof (n2_2 P Q) as n2_2a.
   pose proof (n2_2 P (¬ Q)) as n2_2b.
-  Conj n2_2a n2_2b Ca.
+  Conj_as n2_2a n2_2b Ca.
   pose proof (Comp3_43 P (P ∨ Q) (P ∨ ¬ Q)) as Comp3_43a.
   MP Comp3_43a Ca.
   pose proof (n2_53 P Q) as n2_53a.
   pose proof (n2_53 P (¬ Q)) as n2_53b.
-  Conj n2_53a n2_53b Cb.
+  Conj_as n2_53a n2_53b Cb.
   pose proof (n3_47 (P ∨ Q) (P ∨ ¬ Q) (¬ P → Q) (¬ P → ¬ Q)) as n3_47a.
   MP n3_47a Cb.
   pose proof (n2_65 (¬ P) Q) as n2_65a.
@@ -618,11 +618,11 @@ Proof.
   replace (¬¬ P) with P in n2_65a by now apply n4_13a.
   pose proof (Imp3_31 (¬ P → Q) (¬ P → ¬ Q) (P)) as Imp3_31a.
   MP Imp3_31a n2_65a.
-  Syll n3_47a Imp3_31a Sa.
+  Syll_as n3_47a Imp3_31a Sa.
   clear n2_2a. clear n2_2b. clear Ca. clear n2_53a.
     clear n2_53b. clear Cb. clear n2_65a.
     clear n3_47a. clear Imp3_31a. clear n4_13a.
-  Conj Comp3_43a Sa Cc.
+  Conj_as Comp3_43a Sa Cc.
   Equiv Cc.
   exact Cc.
 Qed.
@@ -633,11 +633,11 @@ Proof.
   pose proof (n2_2 P (P ∧ Q)) as n2_2a.
   pose proof (Id2_08 P) as Id2_08a.
   pose proof (Simp3_26 P Q) as Simp3_26a.
-  Conj Id2_08a Simp3_26a Ca.
+  Conj_as Id2_08a Simp3_26a Ca.
   pose proof (n3_44 P P (P ∧ Q)) as n3_44a.
   MP n3_44a Ca.
   clear Ca. clear Id2_08a. clear Simp3_26a.
-  Conj n2_2a n3_44a Cb.
+  Conj_as n2_2a n3_44a Cb.
   Equiv Cb.
   exact Cb.
 Qed.
@@ -656,7 +656,7 @@ Proof.
     by now apply n4_24a.
   pose proof (Simp3_26 P (P ∨ Q)) as Simp3_26a.
   clear n4_4a. clear n4_24a.
-  Conj n2_2a Simp3_26a C.
+  Conj_as n2_2a Simp3_26a C.
   Equiv C.
   exact C.
 Qed.
@@ -845,7 +845,7 @@ Theorem n4_64 (P Q : Prop) :
 Proof.
   pose proof (n2_54 P Q) as n2_54a.
   pose proof (n2_53 P Q) as n2_53a.
-  Conj n2_54a n2_53a C.
+  Conj_as n2_54a n2_53a C.
   Equiv C.
   exact C.
 Qed.
@@ -908,7 +908,7 @@ Proof.
   pose proof (Syll2_05 P (P ∧ Q) Q) as Syll2_05a.
   MP Syll2_05a Simp3_27a.
   clear Id2_08a. clear Comp3_43a. clear Simp3_27a.
-  Conj Syll2_05a Exp3_3a C.
+  Conj_as Syll2_05a Exp3_3a C.
   Equiv C.
   exact C.
 Qed.
@@ -926,10 +926,10 @@ Proof.
   replace ((P → P ∧ Q) ∧ (P ∧ Q → P)) with (P ↔ (P ∧ Q)) 
     in Simp3_26b by now rewrite Equiv4_01.
   clear Simp3_26a.
-  Conj n3_21a Simp3_26b Ca.
+  Conj_as n3_21a Simp3_26b Ca.
   Equiv Ca.
   clear n3_21a. clear Simp3_26b.
-  Conj n4_7a Ca Cb.
+  Conj_as n4_7a Ca Cb.
   pose proof (n4_22 (P → Q) (P → P ∧ Q) (P ↔ P ∧ Q)) as n4_22a.
   MP n4_22a Cb.
   exact n4_22a.
@@ -940,16 +940,16 @@ Theorem n4_72 (P Q : Prop) :
 Proof.
   pose proof (Transp4_1 P Q) as Transp4_1a.
   pose proof (n4_71 (¬ Q) (¬ P)) as n4_71a.
-  Conj Transp4_1a n4_71a Ca.
+  Conj_as Transp4_1a n4_71a Ca.
   pose proof (n4_22 (P → Q) (¬ Q → ¬ P) (¬ Q ↔ ¬ Q ∧ ¬ P)) as n4_22a.
   MP n4_22a Ca.
   pose proof (n4_21 (¬ Q) (¬ Q ∧ ¬ P)) as n4_21a.
-  Conj n4_22a n4_21a Cb.
+  Conj_as n4_22a n4_21a Cb.
   pose proof (n4_22 (P → Q) (¬ Q ↔ ¬ Q ∧ ¬ P) 
     (¬ Q ∧ ¬ P ↔ ¬ Q)) as n4_22b.
   MP n4_22b Cb.
   pose proof (n4_12 (¬ Q ∧ ¬ P) (Q)) as n4_12a.
-  Conj n4_22b n4_12a Cc.
+  Conj_as n4_22b n4_12a Cc.
   pose proof (n4_22 (P → Q) ((¬ Q ∧ ¬ P) ↔ ¬ Q) 
     (Q ↔ ¬ (¬ Q ∧ ¬ P))) as n4_22c.
   MP n4_22b Cc.
@@ -977,7 +977,7 @@ Proof.
   pose proof (Simp3_26 ((P → Q) → P ↔ P ∧ Q) 
     (P ↔ P ∧ Q → P → Q)) as Simp3_26a.
   MP Simp3_26a n4_71a.
-  Syll Simp2_02a Simp3_26a Sa.
+  Syll_as Simp2_02a Simp3_26a Sa.
   exact Sa.
 Qed.
 
@@ -1019,13 +1019,13 @@ Proof.
   MP Syll2_06a n2_2a.
   pose proof (Syll2_06 R (Q ∨ R) P) as Syll2_06b.
   MP Syll2_06b Add1_3a.
-  Conj Syll2_06a Syll2_06b Ca.
+  Conj_as Syll2_06a Syll2_06b Ca.
   pose proof (Comp3_43  ((Q ∨ R) → P)
     (Q → P) (R → P)) as Comp3_43a.
   MP Comp3_43a Ca.
   clear n2_2a. clear Add1_3a. clear Ca.
     clear Syll2_06a. clear Syll2_06b.
-  Conj n3_44a Comp3_43a Cb.
+  Conj_as n3_44a Comp3_43a Cb.
   Equiv Cb.
   exact Cb.
 Qed.
@@ -1093,7 +1093,7 @@ Theorem n4_79 (P Q R : Prop) :
 Proof.
   pose proof (Transp4_1 Q P) as Transp4_1a.
   pose proof (Transp4_1 R P) as Transp4_1b.
-  Conj Transp4_1a Transp4_1b Ca.
+  Conj_as Transp4_1a Transp4_1b Ca.
   pose proof (n4_39 
       (Q → P) (R → P) (¬ P → ¬ Q) (¬ P → ¬ R)) as n4_39a.
   MP n4_39a Ca.
@@ -1117,18 +1117,18 @@ Proof.
     (¬ P → (¬ Q ∨ ¬ R)) ((¬ P → ¬ Q) ∨ (¬ P → ¬ R))) as Syll2_06b.
   MP Syll2_06b Trans2_15b.
   MP Syll2_06b Simp3_27a.
-  Conj Syll2_06a Syll2_06b Cb.
+  Conj_as Syll2_06a Syll2_06b Cb.
   Equiv Cb.
   clear Transp4_1a. clear Transp4_1b. clear Ca.
     clear Simp3_26a. clear Syll2_06b. clear n4_78a.
     clear Transp2_15a. clear Simp3_27a.
     clear Transp2_15b. clear Syll2_06a.
-  Conj n4_39a Cb Cc.
+  Conj_as n4_39a Cb Cc.
   pose proof (n4_22 ((Q → P) ∨ (R → P))
     ((¬ P → ¬ Q) ∨ (¬ P → ¬ R)) (¬ (¬ Q ∨ ¬ R) → P)) as n4_22a.
   MP n4_22a Cc.
   pose proof (n4_2 (¬ (¬ Q ∨ ¬ R) → P)) as n4_2a.
-  Conj n4_22a n4_2a Cdd.
+  Conj_as n4_22a n4_2a Cdd.
   pose proof (n4_22 ((Q → P) ∨ (R → P))
   (¬ (¬ Q ∨ ¬ R) → P) (¬ (¬ Q ∨ ¬ R) → P)) as n4_22b.
   MP n4_22b Cdd.
@@ -1141,7 +1141,7 @@ Theorem n_8 (P : Prop) :
 Proof.
   pose proof (Abs2_01 P) as Abs2_01a.
   pose proof (Simp2_02 P (¬ P)) as Simp2_02a.
-  Conj Abs2_01a Simp2_02a C.
+  Conj_as Abs2_01a Simp2_02a C.
   Equiv C.
   exact C.
 Qed.
@@ -1151,7 +1151,7 @@ Theorem n_81 (P : Prop) :
 Proof.
   pose proof (n2_18 P) as n2_18a.
   pose proof (Simp2_02 (¬ P) P) as Simp2_02a.
-  Conj n2_18a Simp2_02a C.
+  Conj_as n2_18a Simp2_02a C.
   Equiv C.
   exact C.
 Qed.
@@ -1164,12 +1164,12 @@ Proof.
   MP Imp3_31a n2_65a.
   pose proof (n2_21 P Q) as n2_21a.
   pose proof (n2_21 P (¬ Q)) as n2_21b.
-  Conj n2_21a n2_21b Ca.
+  Conj_as n2_21a n2_21b Ca.
   pose proof (Comp3_43 (¬ P) (P → Q) (P → ¬ Q)) as Comp3_43a.
   MP Comp3_43a Ca.
   clear n2_65a. clear n2_21a.
     clear n2_21b. clear Ca.
-  Conj Imp3_31a Comp3_43a Cb.
+  Conj_as Imp3_31a Comp3_43a Cb.
   Equiv Cb.
   exact Cb.
 Qed.
@@ -1182,12 +1182,12 @@ Proof.
   MP Imp3_31a n2_61a.
   pose proof (Simp2_02 P Q) as Simp2_02a.
   pose proof (Simp2_02 (¬ P) Q) as Simp2_02b.
-  Conj Simp2_02a Simp2_02b Ca.
+  Conj_as Simp2_02a Simp2_02b Ca.
   pose proof (Comp3_43 Q (P → Q) (¬ P → Q)) as Comp3_43a.
   MP Comp3_43a H.
   clear n2_61a. clear Simp2_02a.
   clear Simp2_02b. clear Ca.
-  Conj Imp3_31a Comp3_43a Cb.
+  Conj_as Imp3_31a Comp3_43a Cb.
   Equiv Cb.
   exact Cb.
 Qed.
@@ -1197,7 +1197,7 @@ Theorem n4_84 (P Q R : Prop) :
 Proof.
   pose proof (Syll2_06 P Q R) as Syll2_06a.
   pose proof (Syll2_06 Q P R) as Syll2_06b.
-  Conj Syll2_06a Syll2_06b Ca.
+  Conj_as Syll2_06a Syll2_06b Ca.
   pose proof (n3_47 (P → Q) (Q → P) ((Q → R) → P → R) 
     ((P → R) → Q → R)) as n3_47a.
   MP n3_47a Ca.
@@ -1219,7 +1219,7 @@ Theorem n4_85 (P Q R : Prop) :
 Proof.
   pose proof (Syll2_05 R P Q) as Syll2_05a.
   pose proof (Syll2_05 R Q P) as Syll2_05b.
-  Conj Syll2_05a Syll2_05b Ca.
+  Conj_as Syll2_05a Syll2_05b Ca.
   pose proof (n3_47 (P → Q) (Q → P) ((R → P) → R → Q) 
     ((R → Q) → R → P)) as n3_47a.
   MP n3_47a Ca.
@@ -1244,7 +1244,7 @@ Proof.
   replace (Q ↔ P) with (P ↔ Q) in Exp3_3a
     by now apply n4_21a.
   clear n4_22a. clear n4_22b. clear n4_21a.
-  Conj Exp3_3a Exp3_3b Ca.
+  Conj_as Exp3_3a Exp3_3b Ca.
   pose proof (Comp3_43 (P ↔ Q)
       ((P ↔ R) → (Q ↔ R)) ((Q ↔ R) → (P ↔ R))) as Comp3_43a. (*Not cited*)
   MP Comp3_43a Ca.
@@ -1265,24 +1265,24 @@ Proof.
   {
     pose proof (Exp3_3 P Q R) as Exp3_3.
     pose proof (Imp3_31 P Q R) as Imp3_31.
-    Conj Exp3_3 Imp3_31 C1.
+    Conj_as Exp3_3 Imp3_31 C1.
     now Equiv C1.
   }
   assert (S2 : (P → (Q → R)) ↔ (Q → (P → R))).
   {
     pose proof (Comm2_04 P Q R) as Comm2_04a.
     pose proof (Comm2_04 Q P R) as Comm2_04b.
-    Conj Comm2_04a Comm2_04b C1.
+    Conj_as Comm2_04a Comm2_04b C1.
     now Equiv C1.
   }
   assert (S3 : (Q → (P → R)) ↔ ((Q ∧ P) → R)).
   {
     pose proof (Imp3_31 Q P R) as Imp3_31.
     pose proof (Exp3_3 Q P R) as Exp3_3.
-    Conj Imp3_31 Exp3_3 C1.
+    Conj_as Imp3_31 Exp3_3 C1.
     now Equiv C1.
   }
-  Conj S2 S3 C1.
+  Conj_as S2 S3 C1.
   clear S2 S3.
-  now Conj S1 C1 C2.
+  now Conj_as S1 C1 C2.
 Qed.

--- a/pm/ch4.v
+++ b/pm/ch4.v
@@ -25,8 +25,9 @@ automatically associates to the right, we leave
 this notational axiom commented out.*)
 
 Ltac Equiv H1 :=
-  lazymatch goal with 
-    | [ H1 : (?P → ?Q) ∧ (?Q → ?P) |- _ ] => 
+  match goal with 
+    | [ _H1 : (?P → ?Q) ∧ (?Q → ?P) |- _ ] => 
+      constr_eq H1 _H1;
       replace ((P → Q) ∧ (Q → P)) with (P ↔ Q) in H1
       by now rewrite Equiv4_01
   end.
@@ -50,13 +51,13 @@ Proof.
     pose proof (Transp2_16 Q P) as Transp2_16b.
     Conj_as Transp2_16a Transp2_16b Ca.
     pose proof (n3_47 (P → Q) (Q → P) (¬ Q → ¬ P) (¬ P → ¬ Q)) as n3_47a.
-    MP n3_47 Ca.
+    MP n3_47a Ca.
     pose proof (n3_22 (¬ Q → ¬ P) (¬ P → ¬ Q)) as n3_22a.
     Syll_as n3_47a n3_22a Sa_1.
     exact Sa_1.
   }
   replace ((P → Q) ∧ (Q → P)) with (P ↔ Q) in Sa.
-  replace ((¬ P → ¬ Q) ∧ (¬ Q → ¬ P)) with (¬ P ↔ ¬ Q) in Sa .
+  replace ((¬ P → ¬ Q) ∧ (¬ Q → ¬ P)) with (¬ P ↔ ¬ Q) in Sa.
   assert (Sb : (¬ P → ¬ Q) ∧ (¬ Q → ¬ P) → (P → Q) ∧ (Q → P)).
   {
     pose proof (Transp2_17 Q P) as Transp2_17a.
@@ -87,7 +88,7 @@ Proof.
     exact Ca.
   }
   pose proof (n3_47 (P → ¬ Q) (¬ Q → P) (Q → ¬ P) (¬ P → Q)) as n3_47a.
-  MP n3_47a C.
+  MP n3_47a Ca.
   assert (Cb : ((Q → ¬ P) → P → ¬ Q) ∧ ((¬ P → Q) → ¬ Q → P)).
   {
     pose proof (Transp2_03 Q P) as Transp2_03b.
@@ -96,7 +97,7 @@ Proof.
     exact Cb.
   }
   pose proof (n3_47 (Q → ¬ P) (¬ P → Q) (P → ¬ Q) (¬ Q → P)) as n3_47b.
-  MP n3_47b Ca.
+  MP n3_47b Cb.
   clear Ca Cb.
   Conj_as n3_47a n3_47b Cc.
   rewrite <- Equiv4_01 in Cc.
@@ -166,7 +167,7 @@ Proof.
     pose proof (n3_22 P Q) as n3_22b.
     pose proof (Syll2_06 (P ∧ Q) (Q ∧ P) (¬ R)) as Syll2_06b.
     MP Syll2_06b n3_22b.
-    Syll_as Syll2_06b Simp3_27a Sb.
+    Syll_as Simp3_27a Syll2_06b Sb.
     exact Sb.
   }
   Conj_as Sa Sb C.
@@ -261,7 +262,7 @@ Theorem n4_24 (P : Prop) :
 Proof.
   pose proof (n3_2 P P) as n3_2a.
   pose proof (n2_43 P (P ∧ P)) as n2_43a.
-  MP n3_2a n2_43a.
+  MP n2_43a n3_2a.
   pose proof (Simp3_26 P P) as Simp3_26a.
   Conj_as n2_43a Simp3_26a C.
   Equiv C.
@@ -377,7 +378,7 @@ Proof.
   Conj_as Fact3_45a Fact3_45b C.
   pose proof (n3_47 (P → Q) (Q → P) 
       (P ∧ R → Q ∧ R) (Q ∧ R → P ∧ R)) as n3_47a.
-  MP n3_47 C.
+  MP n3_47a C.
   replace  ((P → Q) ∧ (Q → P)) with (P ↔ Q) in n3_47a.
   replace ((P ∧ R → Q ∧ R) ∧ (Q ∧ R → P ∧ R)) with (P ∧ R ↔ Q ∧ R) in n3_47a.
   exact n3_47a.
@@ -392,7 +393,7 @@ Proof.
   Conj_as Sum1_6a Sum1_6b C.
   pose proof (n3_47 (P → Q) (Q → P) 
       (R ∨ P → R ∨ Q) (R ∨ Q → R ∨ P)) as n3_47a.
-  MP n3_47 C.
+  MP n3_47a C.
   replace  ((P → Q) ∧ (Q → P)) with (P ↔ Q) in n3_47a.
   replace ((R ∨ P → R ∨ Q) ∧ (R ∨ Q → R ∨ P)) with (R ∨ P ↔ R ∨ Q) in n3_47a.
   pose proof (n4_31 Q R) as n4_31a.
@@ -552,14 +553,14 @@ Proof.
   {
     pose proof (Simp3_26 Q R) as Simp3_26a.
     pose proof (Sum1_6 P (Q ∧ R) Q) as Sum1_6a.
-    MP Simp3_26a Sum1_6a.
+    MP Sum1_6a Simp3_26a.
     exact Sum1_6a.
   }
   assert (Sum1_6b: P ∨ Q ∧ R → P ∨ R).
   {
     pose proof (Simp3_27 Q R) as Simp3_27a.
     pose proof (Sum1_6 P (Q ∧ R) R) as Sum1_6b.
-    MP Simp3_27a Sum1_6b.
+    MP Sum1_6b Simp3_27a.
     exact Sum1_6b.
   }
   (* ??? *)
@@ -910,6 +911,7 @@ Proof.
   clear Id2_08a. clear Comp3_43a. clear Simp3_27a.
   Conj_as Syll2_05a Exp3_3a C.
   Equiv C.
+  rewrite -> n4_21 in C.
   exact C.
 Qed.
 
@@ -952,7 +954,7 @@ Proof.
   Conj_as n4_22b n4_12a Cc.
   pose proof (n4_22 (P → Q) ((¬ Q ∧ ¬ P) ↔ ¬ Q) 
     (Q ↔ ¬ (¬ Q ∧ ¬ P))) as n4_22c.
-  MP n4_22b Cc.
+  MP n4_22c Cc.
   pose proof (n4_57 Q P) as n4_57a.
   apply propositional_extensionality in n4_57a.
   symmetry in n4_57a.
@@ -1115,7 +1117,7 @@ Proof.
   MP Syll2_06a Transp2_15a.
   pose proof (Syll2_06 (¬ (¬ Q ∨ ¬ R) → P)
     (¬ P → (¬ Q ∨ ¬ R)) ((¬ P → ¬ Q) ∨ (¬ P → ¬ R))) as Syll2_06b.
-  MP Syll2_06b Trans2_15b.
+  MP Syll2_06b Transp2_15b.
   MP Syll2_06b Simp3_27a.
   Conj_as Syll2_06a Syll2_06b Cb.
   Equiv Cb.
@@ -1184,7 +1186,7 @@ Proof.
   pose proof (Simp2_02 (¬ P) Q) as Simp2_02b.
   Conj_as Simp2_02a Simp2_02b Ca.
   pose proof (Comp3_43 Q (P → Q) (¬ P → Q)) as Comp3_43a.
-  MP Comp3_43a H.
+  MP Comp3_43a Ca.
   clear n2_61a. clear Simp2_02a.
   clear Simp2_02b. clear Ca.
   Conj_as Imp3_31a Comp3_43a Cb.

--- a/pm/ch4.v
+++ b/pm/ch4.v
@@ -98,7 +98,6 @@ Proof.
   }
   pose proof (n3_47 (Q → ¬ P) (¬ P → Q) (P → ¬ Q) (¬ Q → P)) as n3_47b.
   MP n3_47b Cb.
-  clear Ca Cb.
   Conj_as n3_47a n3_47b Cc.
   rewrite <- Equiv4_01 in Cc.
   rewrite <- Equiv4_01 in Cc.
@@ -248,7 +247,6 @@ Proof.
   pose proof (n2_83 ((P ↔ Q) ∧ (Q ↔ R)) R Q P) as n2_83b.
   MP n2_83b Sc.
   MP n2_83b Sd.
-  clear Sa Sb Sc Sd.
   Conj_as n2_83a n2_83b C.
   pose proof (Comp3_43 ((P ↔ Q) ∧ (Q ↔ R)) (P → R) (R → P)) as Comp3_43a.
   MP Comp3_43a C.
@@ -536,11 +534,9 @@ Proof.
   }
   pose proof (n3_48 (P ∧ Q) (P ∧ R) Q R) as n3_48b.
   MP n3_48b Cc.
-  clear Ca Cb Cc Comp3_43a Sa.
   Conj_as n3_44a n3_48b Cdd. (*Cd is reserved*)
   pose proof (Comp3_43 (P ∧ Q ∨ P ∧ R) P (Q ∨ R)) as Comp3_43b.
   MP Comp3_43b Cdd.
-  clear n3_48a n3_44a n3_48b Cdd.
   Conj_as Imp3_31a Comp3_43b Ce.
   Equiv Ce.
   exact Ce.
@@ -576,9 +572,6 @@ Proof.
   Syll_as n3_47a Comp3_43b Sa.
   pose proof (n2_54 P (Q ∧ R)) as n2_54a.
   Syll_as Sa n2_54a Sb.
-  clear Sum1_6a. clear Sum1_6b. clear Ca. clear n2_53a.
-      clear n2_53b. clear Cb. clear n3_47a. clear Sa.
-      clear Comp3_43b. clear n2_54a.
   Conj_as Comp3_43a Sb Cc.
   Equiv Cc.
   exact Cc.
@@ -590,7 +583,7 @@ Proof.
   pose proof (n3_21 P (Q ∨ ¬ Q)) as n3_21a.
   pose proof (n2_11 Q) as n2_11a.
   MP n3_21a n2_11a.
-  pose proof (Simp3_26 P (Q ∨ ¬ Q)) as Simp3_26a. clear n2_11a.
+  pose proof (Simp3_26 P (Q ∨ ¬ Q)) as Simp3_26a.
   Conj_as n3_21a Simp3_26a C.
   Equiv C.
   pose proof (n4_4 P Q (¬ Q)) as n4_4a.
@@ -620,9 +613,6 @@ Proof.
   pose proof (Imp3_31 (¬ P → Q) (¬ P → ¬ Q) (P)) as Imp3_31a.
   MP Imp3_31a n2_65a.
   Syll_as n3_47a Imp3_31a Sa.
-  clear n2_2a. clear n2_2b. clear Ca. clear n2_53a.
-    clear n2_53b. clear Cb. clear n2_65a.
-    clear n3_47a. clear Imp3_31a. clear n4_13a.
   Conj_as Comp3_43a Sa Cc.
   Equiv Cc.
   exact Cc.
@@ -637,7 +627,6 @@ Proof.
   Conj_as Id2_08a Simp3_26a Ca.
   pose proof (n3_44 P P (P ∧ Q)) as n3_44a.
   MP n3_44a Ca.
-  clear Ca. clear Id2_08a. clear Simp3_26a.
   Conj_as n2_2a n3_44a Cb.
   Equiv Cb.
   exact Cb.
@@ -656,7 +645,6 @@ Proof.
   replace (P ∧ P) with P in n2_2a 
     by now apply n4_24a.
   pose proof (Simp3_26 P (P ∨ Q)) as Simp3_26a.
-  clear n4_4a. clear n4_24a.
   Conj_as n2_2a Simp3_26a C.
   Equiv C.
   exact C.
@@ -908,7 +896,6 @@ Proof.
   pose proof (Simp3_27 P Q) as Simp3_27a.
   pose proof (Syll2_05 P (P ∧ Q) Q) as Syll2_05a.
   MP Syll2_05a Simp3_27a.
-  clear Id2_08a. clear Comp3_43a. clear Simp3_27a.
   Conj_as Syll2_05a Exp3_3a C.
   Equiv C.
   rewrite -> n4_21 in C.
@@ -927,10 +914,8 @@ Proof.
   pose proof (Simp3_26 (P → (P ∧ Q)) ((P ∧ Q) → P)) as Simp3_26b.
   replace ((P → P ∧ Q) ∧ (P ∧ Q → P)) with (P ↔ (P ∧ Q)) 
     in Simp3_26b by now rewrite Equiv4_01.
-  clear Simp3_26a.
   Conj_as n3_21a Simp3_26b Ca.
   Equiv Ca.
-  clear n3_21a. clear Simp3_26b.
   Conj_as n4_7a Ca Cb.
   pose proof (n4_22 (P → Q) (P → P ∧ Q) (P ↔ P ∧ Q)) as n4_22a.
   MP n4_22a Cb.
@@ -1025,8 +1010,6 @@ Proof.
   pose proof (Comp3_43  ((Q ∨ R) → P)
     (Q → P) (R → P)) as Comp3_43a.
   MP Comp3_43a Ca.
-  clear n2_2a. clear Add1_3a. clear Ca.
-    clear Syll2_06a. clear Syll2_06b.
   Conj_as n3_44a Comp3_43a Cb.
   Equiv Cb.
   exact Cb.
@@ -1121,10 +1104,6 @@ Proof.
   MP Syll2_06b Simp3_27a.
   Conj_as Syll2_06a Syll2_06b Cb.
   Equiv Cb.
-  clear Transp4_1a. clear Transp4_1b. clear Ca.
-    clear Simp3_26a. clear Syll2_06b. clear n4_78a.
-    clear Transp2_15a. clear Simp3_27a.
-    clear Transp2_15b. clear Syll2_06a.
   Conj_as n4_39a Cb Cc.
   pose proof (n4_22 ((Q → P) ∨ (R → P))
     ((¬ P → ¬ Q) ∨ (¬ P → ¬ R)) (¬ (¬ Q ∨ ¬ R) → P)) as n4_22a.
@@ -1169,8 +1148,6 @@ Proof.
   Conj_as n2_21a n2_21b Ca.
   pose proof (Comp3_43 (¬ P) (P → Q) (P → ¬ Q)) as Comp3_43a.
   MP Comp3_43a Ca.
-  clear n2_65a. clear n2_21a.
-    clear n2_21b. clear Ca.
   Conj_as Imp3_31a Comp3_43a Cb.
   Equiv Cb.
   exact Cb.
@@ -1187,8 +1164,6 @@ Proof.
   Conj_as Simp2_02a Simp2_02b Ca.
   pose proof (Comp3_43 Q (P → Q) (¬ P → Q)) as Comp3_43a.
   MP Comp3_43a Ca.
-  clear n2_61a. clear Simp2_02a.
-  clear Simp2_02b. clear Ca.
   Conj_as Imp3_31a Comp3_43a Cb.
   Equiv Cb.
   exact Cb.
@@ -1245,7 +1220,6 @@ Proof.
   apply propositional_extensionality in n4_21a.
   replace (Q ↔ P) with (P ↔ Q) in Exp3_3a
     by now apply n4_21a.
-  clear n4_22a. clear n4_22b. clear n4_21a.
   Conj_as Exp3_3a Exp3_3b Ca.
   pose proof (Comp3_43 (P ↔ Q)
       ((P ↔ R) → (Q ↔ R)) ((Q ↔ R) → (P ↔ R))) as Comp3_43a. (*Not cited*)
@@ -1285,6 +1259,5 @@ Proof.
     now Equiv C1.
   }
   Conj_as S2 S3 C1.
-  clear S2 S3.
   now Conj_as S1 C1 C2.
 Qed.

--- a/pm/ch5.v
+++ b/pm/ch5.v
@@ -10,9 +10,9 @@ Proof.
   pose proof (n3_4 P Q) as n3_4a.
   pose proof (n3_4 Q P) as n3_4b.
   pose proof (n3_22 P Q) as n3_22a.
-  Syll n3_22a n3_4b Sa.
+  Syll_as n3_22a n3_4b Sa.
   clear n3_22a. clear n3_4b.
-  Conj n3_4a Sa C.
+  Conj_as n3_4a Sa C.
   pose proof (n4_76 (P ∧ Q) (P → Q) (Q → P)) as n4_76a. (*Not cited*)
   apply propositional_extensionality in n4_76a.
   symmetry in n4_76a.
@@ -67,7 +67,7 @@ Proof.
   pose proof (Transp2_16 Q (P → Q)) as Transp2_16a.
   MP Transp2_16a Simp2_02a.
   pose proof (n2_21 Q R) as n2_21a.
-  Syll Transp2_16a n2_21a Sa.
+  Syll_as Transp2_16a n2_21a Sa.
   replace (¬ (P → Q) → (Q → R)) with 
       (¬¬ (P → Q) ∨ (Q → R)) in Sa
       by now rewrite <- Impl1_01.
@@ -89,7 +89,7 @@ Proof.
     ((P ∧ ¬ Q) → ¬ (P → Q))) as Simp3_26a.
   MP Simp3_26a n4_61a.
   pose proof (n5_1 P (¬ Q)) as n5_1a.
-  Syll Simp3_26a n5_1a Sa.
+  Syll_as Simp3_26a n5_1a Sa.
   pose proof (n2_54 (P → Q) (P ↔ ¬ Q)) as n2_54a.
   MP n2_54a Sa.
   pose proof (n4_61 Q P) as n4_61b.
@@ -100,7 +100,7 @@ Proof.
       (¬ (Q → P) → (Q ∧ ¬ P)) ((Q ∧ ¬ P) → (¬ (Q → P)))) as Simp3_26b.
   MP Simp3_26b n4_61b.
   pose proof (n5_1 Q (¬ P)) as n5_1b.
-  Syll Simp3_26b n5_1b Sb.
+  Syll_as Simp3_26b n5_1b Sb.
   pose proof (n4_12 P Q) as n4_12a.
   apply propositional_extensionality in n4_12a.
   replace (Q ↔ ¬ P) with (P ↔ ¬ Q) in Sb 
@@ -125,7 +125,7 @@ Proof.
       clear n2_54a. clear n4_61b. clear Simp3_26b. 
       clear n5_1b. clear n4_12a. clear n2_54b.
       clear n4_13a. clear n4_13b.
-  Conj Sa Sb C.
+  Conj_as Sa Sb C.
   pose proof (n4_31 (P → Q) (P ↔ ¬ Q)) as n4_31a.
   apply propositional_extensionality in n4_31a.
   symmetry in n4_31a.
@@ -177,7 +177,7 @@ Proof.
       by now apply n4_32b.
   replace ((P → Q) ∧ (Q → P)) with (P ↔ Q)
        in Simp3_26a by now rewrite Equiv4_01.
-  Syll Id2_08a Simp3_26a Sa.
+  Syll_as Id2_08a Simp3_26a Sa.
   pose proof (n4_82 P Q) as n4_82a.
   apply propositional_extensionality in n4_82a.
   symmetry in n4_82a.
@@ -191,13 +191,13 @@ Proof.
   replace ((P → Q) ∧ (Q → P)) with (P ↔ Q) 
       in Simp3_27a by now rewrite Equiv4_01.
   pose proof (Syll3_33 Q P (¬ Q)) as Syll3_33a.
-  Syll Simp3_27a Syll2_06a Sb.
+  Syll_as Simp3_27a Syll2_06a Sb.
   pose proof (Abs2_01 Q) as Abs2_01a.
-  Syll Sb Abs2_01a Sc.
+  Syll_as Sb Abs2_01a Sc.
   clear Sb. clear Simp3_26a. clear Id2_08a. 
       clear n4_82a. clear Simp3_27a. clear Syll3_33a. 
       clear Abs2_01a. clear n4_32a. clear n4_32b. clear n4_3a.
-  Conj Sa Sc C.
+  Conj_as Sa Sc C.
   pose proof (Comp3_43 ((P ↔ Q) ∧ (P → ¬ Q)) (¬ P) (¬ Q)) as Comp3_43a.
   MP Comp3_43a C.
   pose proof (n4_65 Q P) as n4_65a.
@@ -262,7 +262,7 @@ Proof.
       by now apply Transp4_11a.
   clear Transp4_11a. clear n4_21a.
   clear n4_31a. clear n4_21b. clear n4_13a.
-  Conj n4_64a n4_63a C.
+  Conj_as n4_64a n4_63a C.
   pose proof (n4_38 (P ∨ Q) (¬ (P ∧ Q)) (¬ Q → P) (P → ¬ Q)) as n4_38a.
   MP n4_38a C.
   replace ((¬ Q → P) ∧ (P → ¬ Q)) with (¬ Q ↔ P)
@@ -279,7 +279,7 @@ Theorem n5_18 (P Q : Prop) :
 Proof.
   pose proof (n5_15 P Q) as n5_15a.
   pose proof (n5_16 P Q) as n5_16a.
-  Conj n5_15a n5_16a C.
+  Conj_as n5_15a n5_16a C.
   pose proof (n5_17 (P ↔ Q) (P ↔ ¬ Q)) as n5_17a.
   rewrite Equiv4_01 in n5_17a.
   pose proof (Simp3_26 
@@ -320,7 +320,7 @@ Theorem n5_22 (P Q : Prop) :
 Proof.
   pose proof (n4_61 P Q) as n4_61a.
   pose proof (n4_61 Q P) as n4_61b.
-  Conj n4_61a n4_61b C.
+  Conj_as n4_61a n4_61b C.
   pose proof (n4_39 (¬ (P → Q)) (¬ (Q → P)) (P ∧ ¬ Q) (Q ∧ ¬ P)) as n4_39a.
   MP n4_39a C.
   pose proof (n4_51 (P → Q) (Q → P)) as n4_51a.
@@ -338,7 +338,7 @@ Theorem n5_23 (P Q : Prop) :
 Proof.
   pose proof (n5_18 P Q) as n5_18a.
   pose proof (n5_22 P (¬ Q)) as n5_22a.
-  Conj n5_18a n5_22a C.
+  Conj_as n5_18a n5_22a C.
   pose proof (n4_22 (P ↔ Q) (¬ (P ↔ ¬ Q)) 
     (P ∧ ¬¬ Q ∨ ¬ Q ∧ ¬ P)) as n4_22a.
   MP n4_22a C.
@@ -369,7 +369,7 @@ Proof.
   MP Simp3_26a n5_23a.
   pose proof (n5_22 P Q) as n5_22a.
     clear n5_23a. clear Transp4_11a.
-  Conj Simp3_26a n5_22a C.
+  Conj_as Simp3_26a n5_22a C.
   pose proof (n4_22 (¬ (P ∧ Q ∨ ¬ P ∧ ¬ Q))
     (¬ (P ↔ Q)) (P ∧ ¬ Q ∨ Q ∧ ¬ P)) as n4_22a.
   pose proof (n4_21 (¬ (P ∧ Q ∨ ¬ P ∧ ¬ Q)) (¬ (P ↔ Q))) as n4_21a.
@@ -386,7 +386,7 @@ Theorem n5_25 (P Q : Prop) :
 Proof.
   pose proof (n2_62 P Q) as n2_62a.
   pose proof (n2_68 P Q) as n2_68a.
-  Conj n2_62a n2_68a C.
+  Conj_as n2_62a n2_68a C.
   Equiv C.
   exact C.
 Qed.
@@ -405,7 +405,7 @@ Proof.
   MP Syll2_05a Simp3_27a.
   clear Comp3_43a. clear Simp3_27a. 
       clear Simp3_26a.
-  Conj Exp3_3a Syll2_05a C.
+  Conj_as Exp3_3a Syll2_05a C.
   Equiv C.
   exact C.
 Qed. 
@@ -418,9 +418,9 @@ Proof.
   pose proof (Exp3_3 
       (P → R) (P → Q) (P → (Q ∧ R))) as Exp3_3a. (*Not cited*)
   pose proof (n3_22 (P → R) (P → Q)) as n3_22a. (*Not cited*)
-  Syll n3_22a Comp3_43a Sa.
+  Syll_as n3_22a Comp3_43a Sa.
   MP Exp3_3a Sa.
-  Syll Simp2_02a Exp3_3a Sb.
+  Syll_as Simp2_02a Exp3_3a Sb.
   pose proof (Imp3_31 R (P → Q) (P → (Q ∧ R))) as Imp3_31a. (*Not cited*)
   MP Imp3_31a Sb.
   exact Imp3_31a.
@@ -432,11 +432,11 @@ Proof.
   pose proof (n4_76 P (Q → R) (R → Q)) as n4_76a.
   pose proof (Exp3_3 P Q R) as Exp3_3a.
   pose proof (Imp3_31 P Q R) as Imp3_31a.
-  Conj Exp3_3a Imp3_31a Ca.
+  Conj_as Exp3_3a Imp3_31a Ca.
   Equiv Ca.
   pose proof (Exp3_3 P R Q) as Exp3_3b.
   pose proof (Imp3_31 P R Q) as Imp3_31b.
-  Conj Exp3_3b Imp3_31b Cb.
+  Conj_as Exp3_3b Imp3_31b Cb.
   Equiv Cb.
   pose proof (n5_3 P Q R) as n5_3a.
   pose proof (n5_3 P R Q) as n5_3b.
@@ -484,7 +484,7 @@ Proof.
   MP Simp3_26a n5_32a.
   pose proof (n4_73 Q P) as n4_73a.
   pose proof (n4_84 Q (Q ∧ P) R) as n4_84a.
-  Syll n4_73a n4_84a Sa.
+  Syll_as n4_73a n4_84a Sa.
   pose proof (n4_3 P Q) as n4_3a.
   apply propositional_extensionality in n4_3a.
   replace (Q ∧ P) with (P ∧ Q) in Sa 
@@ -500,7 +500,7 @@ Proof.
   pose proof (n5_1 Q R) as n5_1a.
   pose proof (Syll2_05 P (Q ∧ R) (Q ↔ R)) as Syll2_05a.
   MP Syll2_05a n5_1a.
-  Syll Comp3_43a Syll2_05a Sa.
+  Syll_as Comp3_43a Syll2_05a Sa.
   exact Sa.
 Qed.
 
@@ -532,7 +532,7 @@ Theorem n5_4 (P Q : Prop) :
 Proof.
   pose proof (n2_43 P Q) as n2_43a.
   pose proof (Simp2_02 (P) (P → Q)) as Simp2_02a.
-  Conj n2_43a Simp2_02a C.
+  Conj_as n2_43a Simp2_02a C.
   Equiv C.
   exact C.
 Qed.
@@ -542,7 +542,7 @@ Theorem n5_41 (P Q R : Prop) :
 Proof.
   pose proof (n2_86 P Q R) as n2_86a.
   pose proof (n2_77 P Q R) as n2_77a.
-  Conj n2_86a n2_77a C.
+  Conj_as n2_86a n2_77a C.
   Equiv C.
   exact C.
 Qed.
@@ -553,14 +553,14 @@ Proof.
   pose proof (n5_3 P Q R) as n5_3a.
   pose proof (Imp3_31 P Q R) as Imp3_31a.
   pose proof (Exp3_3 P Q R) as Exp3_3a.
-  Conj Imp3_31a Exp3_3 Ca.
+  Conj_as Imp3_31a Exp3_3 Ca.
   Equiv Ca.
   apply propositional_extensionality in Ca.
   replace ((P ∧ Q) → R) with (P → Q → R) in n5_3a
     by now apply Ca.
   pose proof (Imp3_31 P Q (P ∧ R)) as Imp3_31b.
   pose proof (Exp3_3 P Q (P ∧ R)) as Exp3_3b.
-  Conj Imp3_31b Exp3_3b Cb.
+  Conj_as Imp3_31b Exp3_3b Cb.
   Equiv Cb.
   apply propositional_extensionality in Cb.
   replace ((P ∧ Q) → (P ∧ R)) with 
@@ -582,7 +582,7 @@ Proof.
     ((P → (Q ∧ R)) → ((P → Q) ∧ (P → R)))) as Simp3_27a.
   MP Simp3_27a n4_76a.
   pose proof (Simp3_27 (P → Q) (P → Q ∧ R)) as Simp3_27d.
-  Syll Simp3_27d Simp3_27a Sa.
+  Syll_as Simp3_27d Simp3_27a Sa.
   pose proof (n5_3 (P → Q) (P → R) (P → (Q ∧ R))) as n5_3a.
   rewrite Equiv4_01 in n5_3a.
   pose proof (Simp3_26 
@@ -601,7 +601,7 @@ Proof.
   MP Simp3_27a Simp3_27b.
   clear n4_76a. clear Simp3_26a. clear Simp3_27a. 
     clear Simp3_27b. clear Simp3_27d. clear n5_3a.
-  Conj Simp3_26b Sa C.
+  Conj_as Simp3_26b Sa C.
   Equiv C.
   pose proof (n5_32 (P → Q) (P → R) (P → (Q ∧ R))) as n5_32a.
   rewrite Equiv4_01 in n5_32a.
@@ -633,7 +633,7 @@ Proof.
   MP n3_42a Simp2_02a.
   MP Exp3_3b n3_42a.
   clear n3_42a. clear Simp2_02a. clear Ass3_35a.
-  Conj Exp3_3a Exp3_3b C.
+  Conj_as Exp3_3a Exp3_3b C.
   pose proof (n3_47 P P ((P → Q) → Q) (Q → (P → Q))) as n3_47a.
   MP n3_47a C.
   pose proof (n4_24 P) as n4_24a. (*Not cited*)
@@ -652,7 +652,7 @@ Proof.
   MP Exp3_3a n5_1a.
   pose proof (Ass3_35 P Q) as Ass3_35a.
   pose proof (Simp3_26 (P ∧ (P → Q)) (Q → P)) as Simp3_26a. (*Not cited*)
-  Syll Simp3_26a Ass3_35a Sa.
+  Syll_as Simp3_26a Ass3_35a Sa.
   pose proof (n4_32 P (P → Q) (Q → P)) as n4_32a. (*Not cited*)
   apply propositional_extensionality in n4_32a.
   symmetry in n4_32a.
@@ -664,7 +664,7 @@ Proof.
   MP Exp3_3b Sa.
   clear n5_1a. clear Ass3_35a. clear n4_32a.
       clear Simp3_26a. clear Sa. 
-  Conj Exp3_3a Exp3_3b C.
+  Conj_as Exp3_3a Exp3_3b C.
   pose proof (n4_76 P (Q → (P ↔ Q)) ((P ↔ Q) → Q)) as n4_76a. (*Not cited*)
   apply propositional_extensionality in n4_76a.
   symmetry in n4_76a.
@@ -721,7 +721,7 @@ Proof.
       (¬ Q ∧ ¬ (P ∧ Q)) in Transp2_16a
       by now apply n4_56a.
   pose proof (n5_1 (¬ Q) (¬ (P ∧ Q))) as n5_1a.
-  Syll Transp2_16a n5_1a Sa.
+  Syll_as Transp2_16a n5_1a Sa.
   replace (¬ (P ↔ P ∧ Q) → (¬ Q ↔ ¬ (P ∧ Q))) with 
       (¬¬ (P ↔ P ∧ Q) ∨ (¬ Q ↔ ¬ (P ∧ Q))) in Sa
       by now rewrite Impl1_01. (*Not cited*)
@@ -775,11 +775,11 @@ Proof.
   symmetry in n4_3b.
   replace ((P ∨ Q) ∧ P) with (P ∧ (P ∨ Q)) in Add1_3a
     by now apply n4_3b.
-  Syll Add1_3a n5_1a Sa.
+  Syll_as Add1_3a n5_1a Sa.
   pose proof (n4_74 P Q) as n4_74a.
   pose proof (Transp2_15 P (Q ↔ P ∨ Q)) as Transp2_15a. (*Not cited*)
   MP Transp2_15a n4_74a.
-  Syll Transp2_15a Sa Sb.
+  Syll_as Transp2_15a Sa Sb.
   replace (¬ (Q ↔ P ∨ Q) → P ↔ P ∨ Q) with
     (¬¬ (Q ↔ P ∨ Q) ∨ (P ↔ P ∨ Q)) in Sb 
     by now rewrite Impl1_01.
@@ -823,7 +823,7 @@ Proof.
     MP n4_85 n4_64.
     now rewrite -> n4_85 in n4_87ar.
   }
-  Conj S1 S2 C1.
+  Conj_as S1 S2 C1.
   now Equiv C1.
 Qed.
 
@@ -918,14 +918,14 @@ Theorem n5_7 (P Q R : Prop) :
 Proof.
   pose proof (n4_74 R P) as n4_74a.
   pose proof (n4_74 R Q) as n4_74b. (*Greg's suggestion*)
-  Conj n4_74a n4_74b Ca.
+  Conj_as n4_74a n4_74b Ca.
   pose proof (Comp3_43 (¬ R) (P ↔ R ∨ P) (Q ↔ R ∨ Q)) as Comp3_43a.
   MP Comp3_43a Ca.
   pose proof (n4_22 P (R ∨ P) (R ∨ Q)) as n4_22a.
   pose proof (n4_22 P (R ∨ Q) Q) as n4_22b.
   pose proof (Exp3_3 (P ↔ (R ∨ Q)) ((R ∨ Q) ↔ Q) (P ↔ Q)) as Exp3_3a.
   MP Exp3_3a n4_22b.
-  Syll n4_22a Exp3_3a Sa.
+  Syll_as n4_22a Exp3_3a Sa.
   pose proof (Imp3_31 ((P ↔ (R ∨ P)) ∧
     ((R ∨ P) ↔ (R ∨ Q))) ((R ∨ Q) ↔ Q) (P ↔ Q)) as Imp3_31a.
   MP Imp3_31a Sa.
@@ -958,7 +958,7 @@ Proof.
   symmetry in n4_21a.
   replace (Q ↔ R ∨ Q) with (R ∨ Q ↔ Q) in Comp3_43a
     by now apply n4_21a.
-  Syll Comp3_43a Exp3_3b Sb.
+  Syll_as Comp3_43a Exp3_3b Sb.
   pose proof (n4_31 P R) as n4_31a.
   apply propositional_extensionality in n4_31a.
   replace (R ∨ P) with (P ∨ R) in Sb by now apply n4_31a.
@@ -983,13 +983,13 @@ Proof.
     by now apply n4_13a.
   pose proof (Add1_3 P R) as Add1_3a.
   pose proof (Add1_3 Q R) as Add1_3b.
-  Conj Add1_3a Add1_3b Cb.
+  Conj_as Add1_3a Add1_3b Cb.
   pose proof (Comp3_43 (R) (P ∨ R) (Q ∨ R)) as Comp3_43b.
   MP Comp3_43b Cb.
   pose proof (n5_1 (P ∨ R) (Q ∨ R)) as n5_1a.
-  Syll Comp3_43b n5_1a Sc.
+  Syll_as Comp3_43b n5_1a Sc.
   pose proof (n4_37 P Q R) as n4_37a.
-  Conj Sc n4_37a Cc.
+  Conj_as Sc n4_37a Cc.
   pose proof (n4_77 (P ∨ R ↔ Q ∨ R)
     R (P ↔ Q)) as n4_77a.
   rewrite Equiv4_01 in n4_77a.
@@ -1010,7 +1010,7 @@ Proof.
     clear Exp3_3a. clear Exp3_3b. clear Sb. clear Sc.
     clear n4_13a. clear n4_3a. clear n4_3b. clear n4_21a.
     clear n4_31a. clear n4_31b. clear n4_32a. clear n4_32b.
-  Conj Exp3_3c Simp3_26a Cdd.
+  Conj_as Exp3_3c Simp3_26a Cdd.
   Equiv Cdd.
   exact Cdd.
 Qed.
@@ -1037,7 +1037,7 @@ Proof.
     destruct n4_62 as [n4_62l _].
     pose proof (n4_51 Q R) as n4_51.
     destruct n4_51 as [_ n4_51r].
-    Syll n4_62l n4_51r S2.
+    Syll_as n4_62l n4_51r S2.
     exact S2.
   }
   assert (S3 : (Q → ¬ R) → ((P ∧ R ∨ Q ∧ R) ↔ P ∧ R)).
@@ -1046,7 +1046,7 @@ Proof.
     symmetry in n4_74.
     replace (Q ∧ R ∨ P ∧ R) with (P ∧ R ∨ Q ∧ R) in n4_74
       by (apply propositional_extensionality; split; apply Perm1_4).
-    Syll S2 n4_74 S3.
+    Syll_as S2 n4_74 S3.
     exact S3.
   }
   assert (S4 : (Q → ¬ R) → (((P ∨ Q) ∧ R) ↔ (P ∧ R))).
@@ -1059,7 +1059,7 @@ Proof.
     {
       pose proof (S3 Hp) as S3.
       clear Hp S2.
-      Conj S3_1 S1 C1.
+      Conj_as S3_1 S1 C1.
       exact C1.
     }
     pose proof (n4_22 ((P ∨ Q) ∧ R) (P ∧ R ∨ Q ∧ R)
@@ -1075,7 +1075,7 @@ Theorem n5_74 (P Q R : Prop) :
 Proof.
   pose proof (n5_41 P Q R) as n5_41a.
   pose proof (n5_41 P R Q) as n5_41b.
-  Conj n5_41a n5_41b C.
+  Conj_as n5_41a n5_41b C.
   pose proof (n4_38 
       ((P → Q) → (P → R)) ((P → R) → (P → Q)) 
       (P → Q → R) (P → R → Q)) as n4_38a.
@@ -1116,36 +1116,36 @@ Proof.
   replace ((P → (Q ∨ R)) ∧ ((Q ∨ R) → P)) with 
       (P ↔ (Q ∨ R)) in Simp3_26a
       by now rewrite Equiv4_01.
-  Syll Simp3_26a Simp3_27a Sa.
+  Syll_as Simp3_26a Simp3_27a Sa.
   pose proof (Simp3_27 
     (R → ¬ Q) (P ↔ (Q ∨ R))) as Simp3_27b.
-  Syll Simp3_27b Sa Sb.
+  Syll_as Simp3_27b Sa Sb.
   pose proof (Simp3_27 
     (P → (Q ∨ R)) ((Q ∨ R) → P)) as Simp3_27c.
   replace ((P → (Q ∨ R)) ∧ ((Q ∨ R) → P)) with 
       (P ↔ (Q ∨ R)) in Simp3_27c 
       by now rewrite Equiv4_01.
-  Syll Simp3_27b Simp3_27c Sc.
+  Syll_as Simp3_27b Simp3_27c Sc.
   pose proof (n4_77 P Q R) as n4_77a.
   apply propositional_extensionality in n4_77a.
   replace (Q ∨ R → P) with ((Q → P) ∧ (R → P)) in Sc
     by now apply n4_77a.
   pose proof (Simp3_27 (Q → P) (R → P)) as Simp3_27d.
-  Syll Sa Simp3_27d Sd.
+  Syll_as Sa Simp3_27d Sd.
   pose proof (Simp3_26 (R → ¬ Q) (P ↔ (Q ∨ R))) as Simp3_26b.
-  Conj Sd Simp3_26b Ca.
+  Conj_as Sd Simp3_26b Ca.
   pose proof (Comp3_43 
       ((R → ¬ Q) ∧ (P ↔ (Q ∨ R))) (R → P) (R → ¬ Q)) as Comp3_43a.
   MP Comp3_43a Ca.
   pose proof (Comp3_43 R P (¬ Q)) as Comp3_43b.
-  Syll Comp3_43a Comp3_43b Se.
+  Syll_as Comp3_43a Comp3_43b Se.
   clear n5_6a. clear Simp3_27a. 
   clear Simp3_27c. clear Simp3_27d. 
   clear Simp3_26a.  clear Comp3_43b. 
   clear Simp3_26b. clear Comp3_43a.
   clear Sa. clear Sc. clear Sd. clear Ca. 
   clear n4_77a. clear Simp3_27b. 
-  Conj Sb Se Cb.
+  Conj_as Sb Se Cb.
   pose proof (Comp3_43 
     ((R → ¬ Q) ∧ (P ↔ Q ∨ R)) 
     (P ∧ ¬ Q → R) (R → P ∧ ¬ Q)) as Comp3_43c.

--- a/pm/ch5.v
+++ b/pm/ch5.v
@@ -193,10 +193,10 @@ Proof.
   pose proof (Comp3_43 ((P ↔ Q) ∧ (P → ¬ Q)) (¬ P) (¬ Q)) as Comp3_43a.
   MP Comp3_43a C.
   pose proof (n4_65 Q P) as n4_65a.
-  pose proof (n4_3 (¬ P) (¬ Q)) as n4_3a.
-  apply propositional_extensionality in n4_3a.
+  pose proof (n4_3 (¬ P) (¬ Q)) as n4_3b.
+  apply propositional_extensionality in n4_3b.
   replace (¬ Q ∧ ¬ P) with (¬ P ∧ ¬ Q) in n4_65a
-    by now apply n4_3a.
+    by now apply n4_3b.
   apply propositional_extensionality in n4_65a.
   replace (¬ P ∧ ¬ Q) with (¬ (¬ Q → P)) in Comp3_43a
     by now apply n4_65a.

--- a/pm/ch5.v
+++ b/pm/ch5.v
@@ -11,7 +11,6 @@ Proof.
   pose proof (n3_4 Q P) as n3_4b.
   pose proof (n3_22 P Q) as n3_22a.
   Syll_as n3_22a n3_4b Sa.
-  clear n3_22a. clear n3_4b.
   Conj_as n3_4a Sa C.
   pose proof (n4_76 (P ∧ Q) (P → Q) (Q → P)) as n4_76a. (*Not cited*)
   apply propositional_extensionality in n4_76a.
@@ -40,7 +39,7 @@ Theorem n5_12 (P Q : Prop) :
 Proof.
   pose proof (n2_51 P Q) as n2_51a.
   pose proof (n2_54 ((P → Q)) (P → ¬ Q)) as n2_54a.
-  MP n2_54a n2_5a.
+  MP n2_54a n2_51a.
   exact n2_54a.
 Qed.
   (*The proof sketch cites n2_52, 
@@ -121,10 +120,6 @@ Proof.
   apply propositional_extensionality in n4_13b.
   replace (¬¬ (Q → P)) with (Q → P) in Sb
     by now apply n4_13b.
-  clear n4_61a. clear Simp3_26a. clear n5_1a. 
-      clear n2_54a. clear n4_61b. clear Simp3_26b. 
-      clear n5_1b. clear n4_12a. clear n2_54b.
-      clear n4_13a. clear n4_13b.
   Conj_as Sa Sb C.
   pose proof (n4_31 (P → Q) (P ↔ ¬ Q)) as n4_31a.
   apply propositional_extensionality in n4_31a.
@@ -191,12 +186,9 @@ Proof.
   replace ((P → Q) ∧ (Q → P)) with (P ↔ Q) 
       in Simp3_27a by now rewrite Equiv4_01.
   pose proof (Syll3_33 Q P (¬ Q)) as Syll3_33a.
-  Syll_as Simp3_27a Syll2_06a Sb.
+  Syll_as Simp3_27a Syll3_33a Sb.
   pose proof (Abs2_01 Q) as Abs2_01a.
   Syll_as Sb Abs2_01a Sc.
-  clear Sb. clear Simp3_26a. clear Id2_08a. 
-      clear n4_82a. clear Simp3_27a. clear Syll3_33a. 
-      clear Abs2_01a. clear n4_32a. clear n4_32b. clear n4_3a.
   Conj_as Sa Sc C.
   pose proof (Comp3_43 ((P ↔ Q) ∧ (P → ¬ Q)) (¬ P) (¬ Q)) as Comp3_43a.
   MP Comp3_43a C.
@@ -260,8 +252,6 @@ Proof.
   replace (P ∧ Q ↔ ¬ (P → ¬ Q)) with 
       (¬ (P ∧ Q) ↔ (P → ¬ Q)) in n4_63a
       by now apply Transp4_11a.
-  clear Transp4_11a. clear n4_21a.
-  clear n4_31a. clear n4_21b. clear n4_13a.
   Conj_as n4_64a n4_63a C.
   pose proof (n4_38 (P ∨ Q) (¬ (P ∧ Q)) (¬ Q → P) (P → ¬ Q)) as n4_38a.
   MP n4_38a C.
@@ -368,7 +358,6 @@ Proof.
   MP Simp3_26a Transp4_11a.
   MP Simp3_26a n5_23a.
   pose proof (n5_22 P Q) as n5_22a.
-    clear n5_23a. clear Transp4_11a.
   Conj_as Simp3_26a n5_22a C.
   pose proof (n4_22 (¬ (P ∧ Q ∨ ¬ P ∧ ¬ Q))
     (¬ (P ↔ Q)) (P ∧ ¬ Q ∨ Q ∧ ¬ P)) as n4_22a.
@@ -403,8 +392,6 @@ Proof.
   pose proof (Syll2_05 (P ∧ Q) (P ∧ R) R) as Syll2_05a.
   pose proof (Simp3_27 P R) as Simp3_27a.
   MP Syll2_05a Simp3_27a.
-  clear Comp3_43a. clear Simp3_27a. 
-      clear Simp3_26a.
   Conj_as Exp3_3a Syll2_05a C.
   Equiv C.
   exact C.
@@ -553,7 +540,7 @@ Proof.
   pose proof (n5_3 P Q R) as n5_3a.
   pose proof (Imp3_31 P Q R) as Imp3_31a.
   pose proof (Exp3_3 P Q R) as Exp3_3a.
-  Conj_as Imp3_31a Exp3_3 Ca.
+  Conj_as Imp3_31a Exp3_3a Ca.
   Equiv Ca.
   apply propositional_extensionality in Ca.
   replace ((P ∧ Q) → R) with (P → Q → R) in n5_3a
@@ -566,7 +553,7 @@ Proof.
   replace ((P ∧ Q) → (P ∧ R)) with 
       (P → Q → (P ∧ R)) in n5_3a by now apply Cb.
   exact n5_3a.
-Qed. 
+Qed.
 
 Theorem n5_44 (P Q R : Prop) :
   (P → Q) → ((P → R) ↔ (P → (Q ∧ R))).
@@ -592,15 +579,13 @@ Proof.
     → (((P → Q) ∧ (P → R)) → (P → (Q ∧ R))))) as Simp3_26b.
   MP Simp3_26b n5_3a.
   pose proof (Simp3_27 
-  ((((P → Q) ∧ (P → R)) → (P → (Q ∧ R))) →
-  (((P → Q) ∧ (P → R)) → ((P → Q) ∧ (P → (Q ∧ R)))))
-  ((((P → Q) ∧ (P → R)) → ((P → Q) ∧ (P → (Q ∧ R))))
-  → (((P → Q) ∧ (P → R)) → (P → (Q ∧ R))))) as Simp3_27b.
+    ((((P → Q) ∧ (P → R)) → (P → (Q ∧ R))) →
+    (((P → Q) ∧ (P → R)) → ((P → Q) ∧ (P → (Q ∧ R)))))
+    ((((P → Q) ∧ (P → R)) → ((P → Q) ∧ (P → (Q ∧ R))))
+    → (((P → Q) ∧ (P → R)) → (P → (Q ∧ R))))) as Simp3_27b.
   MP Simp3_27b n5_3a.
-  MP Simp3_26a Simp3_26b.
-  MP Simp3_27a Simp3_27b.
-  clear n4_76a. clear Simp3_26a. clear Simp3_27a. 
-    clear Simp3_27b. clear Simp3_27d. clear n5_3a.
+  MP Simp3_26b Simp3_26a.
+  MP Simp3_27b Simp3_26b.
   Conj_as Simp3_26b Sa C.
   Equiv C.
   pose proof (n5_32 (P → Q) (P → R) (P → (Q ∧ R))) as n5_32a.
@@ -632,7 +617,6 @@ Proof.
   pose proof (n3_42 P Q (P → Q)) as n3_42a. (*Not cited*)
   MP n3_42a Simp2_02a.
   MP Exp3_3b n3_42a.
-  clear n3_42a. clear Simp2_02a. clear Ass3_35a.
   Conj_as Exp3_3a Exp3_3b C.
   pose proof (n3_47 P P ((P → Q) → Q) (Q → (P → Q))) as n3_47a.
   MP n3_47a C.
@@ -662,8 +646,6 @@ Proof.
     by now rewrite Equiv4_01.
   pose proof (Exp3_3 P (P ↔ Q) Q) as Exp3_3b.
   MP Exp3_3b Sa.
-  clear n5_1a. clear Ass3_35a. clear n4_32a.
-      clear Simp3_26a. clear Sa. 
   Conj_as Exp3_3a Exp3_3b C.
   pose proof (n4_76 P (Q → (P ↔ Q)) ((P ↔ Q) → Q)) as n4_76a. (*Not cited*)
   apply propositional_extensionality in n4_76a.
@@ -701,7 +683,7 @@ Proof.
   pose proof (n4_73 P Q) as n4_73a.
   pose proof (n4_44 Q P) as n4_44a.
   pose proof (Transp2_16 Q (P ↔ (P ∧ Q))) as Transp2_16a.
-  MP n4_73a Transp2_16a.
+  MP Transp2_16a n4_73a.
   pose proof (n4_3 P Q) as n4_3a. (*Not cited*)
   apply propositional_extensionality in n4_3a.
   replace (Q ∧ P) with (P ∧ Q) in n4_44a
@@ -1000,16 +982,8 @@ Proof.
     ((R ∨ (P ↔ Q) → P ∨ R ↔ Q ∨ R)
       → (R → P ∨ R ↔ Q ∨ R) ∧
         (P ↔ Q → P ∨ R ↔ Q ∨ R))) as Simp3_26a.
-  MP Simp3_26 n4_77a.
+  MP Simp3_26a n4_77a.
   MP Simp3_26a Cc.
-  clear n4_77a. clear Cc. clear n4_37a. clear Sa.
-    clear n5_1a. clear Comp3_43b. clear Cb. 
-    clear Add1_3a. clear Add1_3b. clear Ca. clear Imp3_31b.
-    clear n4_74a. clear n4_74b. clear Comp3_43a.
-    clear Imp3_31a. clear n4_22a. clear n4_22b. 
-    clear Exp3_3a. clear Exp3_3b. clear Sb. clear Sc.
-    clear n4_13a. clear n4_3a. clear n4_3b. clear n4_21a.
-    clear n4_31a. clear n4_31b. clear n4_32a. clear n4_32b.
   Conj_as Exp3_3c Simp3_26a Cdd.
   Equiv Cdd.
   exact Cdd.
@@ -1054,14 +1028,8 @@ Proof.
     (* This has been very confusing and unrigorous for the proof: the 
       substitution is not done on the whole proposition *)
     intro Hp.
-    (* We have to clear everything else just to do the right `Conj` *)
-    assert (C1 : ((P ∨ Q) ∧ R ↔ P ∧ R ∨ Q ∧ R) ∧ (P ∧ R ∨ Q ∧ R ↔ P ∧ R)).
-    {
-      pose proof (S3 Hp) as S3.
-      clear Hp S2.
-      Conj_as S3_1 S1 C1.
-      exact C1.
-    }
+    pose proof (S3 Hp) as S3.
+    Conj_as S1 S3 C1.
     pose proof (n4_22 ((P ∨ Q) ∧ R) (P ∧ R ∨ Q ∧ R)
         (P ∧ R)) as n4_22.
     MP n4_22 C1.
@@ -1131,7 +1099,7 @@ Proof.
   replace (Q ∨ R → P) with ((Q → P) ∧ (R → P)) in Sc
     by now apply n4_77a.
   pose proof (Simp3_27 (Q → P) (R → P)) as Simp3_27d.
-  Syll_as Sa Simp3_27d Sd.
+  Syll_as Sc Simp3_27d Sd.
   pose proof (Simp3_26 (R → ¬ Q) (P ↔ (Q ∨ R))) as Simp3_26b.
   Conj_as Sd Simp3_26b Ca.
   pose proof (Comp3_43 
@@ -1139,12 +1107,6 @@ Proof.
   MP Comp3_43a Ca.
   pose proof (Comp3_43 R P (¬ Q)) as Comp3_43b.
   Syll_as Comp3_43a Comp3_43b Se.
-  clear n5_6a. clear Simp3_27a. 
-  clear Simp3_27c. clear Simp3_27d. 
-  clear Simp3_26a.  clear Comp3_43b. 
-  clear Simp3_26b. clear Comp3_43a.
-  clear Sa. clear Sc. clear Sd. clear Ca. 
-  clear n4_77a. clear Simp3_27b. 
   Conj_as Sb Se Cb.
   pose proof (Comp3_43 
     ((R → ¬ Q) ∧ (P ↔ Q ∨ R)) 

--- a/pm/ch9.v
+++ b/pm/ch9.v
@@ -461,7 +461,7 @@ Proof.
   { apply Add1_3. }
   assert (S2 : ∀ x, φ x → P ∨ φ x).
   { 
-    pose proof (n9_13 (fun x => φ x → P ∨ φ x) X).
+    pose proof (n9_13 (fun x => φ x → P ∨ φ x) X) as n9_13.
     now MP n9_13 S1.
   }
   assert (S3 : (∀ x, φ x) → (∀ x, P ∨ φ x)).
@@ -484,7 +484,7 @@ Proof.
   { apply Add1_3. }
   assert (S2 : ∀ x, φ x → P ∨ φ x).
   { 
-    pose proof (n9_13 (fun x => φ x → P ∨ φ x) X).
+    pose proof (n9_13 (fun x => φ x → P ∨ φ x) X) as n9_13.
     now MP n9_13 S1.
   }
   assert (S3 : (∃ x, φ x) → (∃ x, P ∨ φ x)).
@@ -509,7 +509,7 @@ Proof.
     pose proof (n9_13 (fun x => P ∨ φ x → φ x ∨ P) X) as n9_13.
     MP n9_13 S1.
     pose proof (n9_21 (fun x => P ∨ φ x) (fun x => φ x ∨ P)) as n9_21.
-    now MP n9_21 S1.
+    now MP n9_21 n9_13.
   }
   assert (S3 : P ∨ (∀ x, φ x) → (∀ x, φ x) ∨ P).
   { now rewrite <- (n9_04 φ P), <- (n9_03 φ P) in S2. }
@@ -593,7 +593,7 @@ Proof.
     pose proof (n9_13 (fun x => P ∨ Q ∨ φ x → Q ∨ P ∨ φ x) X) as n9_13.
     MP n9_13 Assoc1_5.
     pose proof (n9_21 (fun x => P ∨ Q ∨ φ x) (fun x => Q ∨ P ∨ φ x)) as n9_21.
-    now MP n9_21 Assoc1_5.
+    now MP n9_21 n9_13.
   }
   assert (S2 : P ∨ Q ∨ (∀ x, φ x) → Q ∨ P ∨ (∀ x, φ x)).
   {
@@ -606,14 +606,10 @@ Proof.
       optionally `rewrite on equiv`, as it requires relatively lowest 
       setups
     *)
-    assert (Sy1 : P ∨ Q ∨ (∀ x, φ x) → Q ∨ P ∨ ∀ x, φ x).
-    {
-      pose proof (n2_32 Q P (∀ x, φ x)) as n2_32.
-      Syll_as S1 n2_32 S1_1.
-      clear S1 n2_32.
-      pose proof (n2_31 P Q (∀ x, φ x)) as n2_31.
-      now Syll_as S1_1 n2_31 S1_2.
-    }
+    pose proof (n2_32 Q P (∀ x, φ x)) as n2_32.
+    Syll_as S1 n2_32 S1_1.
+    pose proof (n2_31 P Q (∀ x, φ x)) as n2_31.
+    Syll_as n2_31 S1_1 S2.
     (* 
     replace ((P ∨ Q) ∨ (∀ x, φ x)) with (P ∨ Q ∨ ∀ x, φ x) in S1.
     replace ((Q ∨ P) ∨ ∀ x, φ x) with (Q ∨ P ∨ ∀ x, φ x) in S1.
@@ -621,7 +617,7 @@ Proof.
       apply propositional_extensionality; split; [ apply n2_31 | apply n2_32 ]; exact H0
     ). 
     *)
-    exact Sy1.
+    exact S2.
   }
   exact S2.
 Qed.
@@ -862,11 +858,8 @@ Proof.
   }
   assert (S2 : (∃ x, P → φ x) → (∃ x, (P ∨ R) → (φ x ∨ R))).
   {
-    assert (Sy1 : (P → φ X) → (∃ x, (P ∨ R) → (φ x ∨ R))).
-    {
-      pose proof (n9_1 (fun x => P ∨ R → φ x ∨ R) X) as n9_1.
-      now Syll_as S1 n9_1 Sy1.
-    }
+    pose proof (n9_1 (fun x => P ∨ R → φ x ∨ R) X) as n9_1.
+    Syll_as S1 n9_1 Sy1.
     pose proof (n9_13 (fun y => (P → φ y) → (∃ x, (P ∨ R) → (φ x ∨ R))) X)
       as n9_13.
     MP n9_13 Sy1.

--- a/pm/ch9.v
+++ b/pm/ch9.v
@@ -582,7 +582,7 @@ Proof.
     intros P1 Q1 R1.
     pose proof (n2_32 P1 Q1 R1) as n2_32.
     pose proof (n2_31 P1 Q1 R1) as n2_31.
-    Conj n2_32 n2_31 C1.
+    Conj_as n2_32 n2_31 C1.
     now Equiv C1.
   }
   set (X := Intro_individual "x").
@@ -609,10 +609,10 @@ Proof.
     assert (Sy1 : P ∨ Q ∨ (∀ x, φ x) → Q ∨ P ∨ ∀ x, φ x).
     {
       pose proof (n2_32 Q P (∀ x, φ x)) as n2_32.
-      Syll S1 n2_32 S1_1.
+      Syll_as S1 n2_32 S1_1.
       clear S1 n2_32.
       pose proof (n2_31 P Q (∀ x, φ x)) as n2_31.
-      now Syll S1_1 n2_31 S1_2.
+      now Syll_as S1_1 n2_31 S1_2.
     }
     (* 
     replace ((P ∨ Q) ∨ (∀ x, φ x)) with (P ∨ Q ∨ ∀ x, φ x) in S1.
@@ -751,13 +751,13 @@ Proof.
   assert (S2 : (P → Q) → ∃ x, (P ∨ φ x) → (Q ∨ φ Y)).
   {
     pose proof (n9_1 (fun x => P ∨ φ x → Q ∨ φ Y) Y) as n9_1.
-    now Syll S1 n9_1 S2.
+    now Syll_as S1 n9_1 S2.
   }
   assert (S3 : (P → Q) → ∀ y, ∃ x, (P ∨ φ x) → (Q ∨ φ y)).
   { 
     (* *9.04 ignored - optional *)
     pose proof (n9_13 (fun y => ∃ x, P ∨ φ x → Q ∨ φ y) Y) as n9_13.
-    now Syll S2 n9_13 S3.
+    now Syll_as S2 n9_13 S3.
   }
   assert (S4 : (P → Q) → (∃ x, ¬ (P ∨ φ x)) ∨ (∀ y, Q ∨ φ y)).
   { 
@@ -787,12 +787,12 @@ Proof.
   assert (S2 : (P → Q) → ∃ y, (P ∨ φ Y) → (Q ∨ φ y)).
   {
     pose proof (n9_1 (fun y => P ∨ φ Y → Q ∨ φ y) Y) as n9_1.
-    now Syll S1 n9_1 S2.
+    now Syll_as S1 n9_1 S2.
   }
   assert (S3 : (P → Q) → ∀ x, ∃ y, (P ∨ φ x) → (Q ∨ φ y)).
   { 
     pose proof (n9_13 (fun x => ∃ y, P ∨ φ x → Q ∨ φ y) Y) as n9_13.
-    now Syll S2 n9_13 S3.
+    now Syll_as S2 n9_13 S3.
   }
   assert (S4 : (P → Q) → (∀ x, ¬ (P ∨ φ x)) ∨ (∃ y, Q ∨ φ y)).
   {
@@ -865,7 +865,7 @@ Proof.
     assert (Sy1 : (P → φ X) → (∃ x, (P ∨ R) → (φ x ∨ R))).
     {
       pose proof (n9_1 (fun x => P ∨ R → φ x ∨ R) X) as n9_1.
-      now Syll S1 n9_1 Sy1.
+      now Syll_as S1 n9_1 Sy1.
     }
     pose proof (n9_13 (fun y => (P → φ y) → (∃ x, (P ∨ R) → (φ x ∨ R))) X)
       as n9_13.

--- a/pm/experiment/ch9_new.v
+++ b/pm/experiment/ch9_new.v
@@ -600,7 +600,7 @@ Proof.
     intros P1 Q1 R1.
     pose proof (n2_32 P1 Q1 R1) as n2_32.
     pose proof (n2_31 P1 Q1 R1) as n2_31.
-    Conj n2_32 n2_31 C1.
+    Conj_as n2_32 n2_31 C1.
     now Equiv C1.
   }
   set (X := Intro_individual "x").
@@ -627,10 +627,10 @@ Proof.
     assert (Sy1 : P ∨ Q ∨ (∀ x, φ x) → Q ∨ P ∨ ∀ x, φ x).
     {
       pose proof (n2_32 Q P (∀ x, φ x)) as n2_32.
-      Syll S1 n2_32 S1_1.
+      Syll_as S1 n2_32 S1_1.
       clear S1 n2_32.
       pose proof (n2_31 P Q (∀ x, φ x)) as n2_31.
-      now Syll S1_1 n2_31 S1_2.
+      now Syll_as S1_1 n2_31 S1_2.
     }
     (* 
     replace ((P ∨ Q) ∨ (∀ x, φ x)) with (P ∨ Q ∨ ∀ x, φ x) in S1.
@@ -769,13 +769,13 @@ Proof.
   assert (S2 : (P → Q) → ∃ x, (P ∨ φ x) → (Q ∨ φ Y)).
   {
     pose proof (n9_1 (fun x => P ∨ φ x → Q ∨ φ Y) Y) as n9_1.
-    now Syll S1 n9_1 S2.
+    now Syll_as S1 n9_1 S2.
   }
   assert (S3 : (P → Q) → ∀ y, ∃ x, (P ∨ φ x) → (Q ∨ φ y)).
   { 
     (* *9.04 ignored - optional *)
     pose proof (n9_13 (fun y => ∃ x, P ∨ φ x → Q ∨ φ y) Y) as n9_13.
-    now Syll S2 n9_13 S3.
+    now Syll_as S2 n9_13 S3.
   }
   assert (S4 : (P → Q) → (∃ x, ¬ (P ∨ φ x)) ∨ (∀ y, Q ∨ φ y)).
   { 
@@ -805,12 +805,12 @@ Proof.
   assert (S2 : (P → Q) → ∃ y, (P ∨ φ Y) → (Q ∨ φ y)).
   {
     pose proof (n9_1 (fun y => P ∨ φ Y → Q ∨ φ y) Y) as n9_1.
-    now Syll S1 n9_1 S2.
+    now Syll_as S1 n9_1 S2.
   }
   assert (S3 : (P → Q) → ∀ x, ∃ y, (P ∨ φ x) → (Q ∨ φ y)).
   { 
     pose proof (n9_13 (fun x => ∃ y, P ∨ φ x → Q ∨ φ y) Y) as n9_13.
-    now Syll S2 n9_13 S3.
+    now Syll_as S2 n9_13 S3.
   }
   assert (S4 : (P → Q) → (∀ x, ¬ (P ∨ φ x)) ∨ (∃ y, Q ∨ φ y)).
   {
@@ -883,7 +883,7 @@ Proof.
     assert (Sy1 : (P → φ X) → (∃ x, (P ∨ R) → (φ x ∨ R))).
     {
       pose proof (n9_1 (fun x => P ∨ R → φ x ∨ R) X) as n9_1.
-      now Syll S1 n9_1 Sy1.
+      now Syll_as S1 n9_1 Sy1.
     }
     pose proof (n9_13 (fun y => (P → φ y) → (∃ x, (P ∨ R) → (φ x ∨ R))) X)
       as n9_13.

--- a/pm/misc/Jorgensen3_47.v
+++ b/pm/misc/Jorgensen3_47.v
@@ -8,18 +8,18 @@ Theorem n3_47a (P Q R S : Prop) :
 Proof.
   pose proof (Simp3_26 (P → R) (Q → S)) as Simp3_26a.
   pose proof (Fact3_45 P R Q) as Fact3_45a.
-  Syll Fact3_45a Simp3_26a Sa.
+  Syll_as Fact3_45a Simp3_26a Sa.
   pose proof (n3_22 R Q) as n3_22a.
   pose proof (Syll2_05 (P ∧ Q) (R ∧ Q) (Q ∧ R)) as Syll2_05a. (*Not cited by Jorgensen*)
   MP Syl2_05a n3_22a.
-  Syll Sa Syll2_05a Sb.
+  Syll_as Sa Syll2_05a Sb.
   pose proof (Simp3_27 (P → R) (Q → S)) as Simp3_27a.
   pose proof (Fact3_45 Q S R) as Fact3_45b.
-  Syll Simp3_26a Fact3_45b Sc.
+  Syll_as Simp3_26a Fact3_45b Sc.
   pose proof (n3_22 S R) as n3_22b.
   pose proof (Syll2_05 (Q ∧ R) (S ∧ R) (R ∧ S)) as Syll2_05b. (*Not cited by Jorgensen*)
   MP Syl2_05b n3_22b.
-  Syll Sc Syll2_05a Sd.
+  Syll_as Sc Syll2_05a Sd.
   pose proof (n2_83 ((P → R) ∧ (Q → S)) (P ∧ Q) (Q ∧ R) (R ∧ S)) as n2_83a. (*This with MP works, but it omits Conj3_03.*)
   MP n2_83a Sb.
   MP n2_83a Sd.

--- a/pm/misc/Jorgensen3_47.v
+++ b/pm/misc/Jorgensen3_47.v
@@ -8,18 +8,18 @@ Theorem n3_47a (P Q R S : Prop) :
 Proof.
   pose proof (Simp3_26 (P → R) (Q → S)) as Simp3_26a.
   pose proof (Fact3_45 P R Q) as Fact3_45a.
-  Syll_as Fact3_45a Simp3_26a Sa.
+  Syll_as Simp3_26a Fact3_45a Sa.
   pose proof (n3_22 R Q) as n3_22a.
   pose proof (Syll2_05 (P ∧ Q) (R ∧ Q) (Q ∧ R)) as Syll2_05a. (*Not cited by Jorgensen*)
-  MP Syl2_05a n3_22a.
+  MP Syll2_05a n3_22a.
   Syll_as Sa Syll2_05a Sb.
   pose proof (Simp3_27 (P → R) (Q → S)) as Simp3_27a.
   pose proof (Fact3_45 Q S R) as Fact3_45b.
-  Syll_as Simp3_26a Fact3_45b Sc.
+  Syll_as Simp3_27a Fact3_45b Sc.
   pose proof (n3_22 S R) as n3_22b.
   pose proof (Syll2_05 (Q ∧ R) (S ∧ R) (R ∧ S)) as Syll2_05b. (*Not cited by Jorgensen*)
-  MP Syl2_05b n3_22b.
-  Syll_as Sc Syll2_05a Sd.
+  MP Syll2_05b n3_22b.
+  Syll_as Sc Syll2_05b Sd.
   pose proof (n2_83 ((P → R) ∧ (Q → S)) (P ∧ Q) (Q ∧ R) (R ∧ S)) as n2_83a. (*This with MP works, but it omits Conj3_03.*)
   MP n2_83a Sb.
   MP n2_83a Sd.

--- a/pm/misc/Lemma5_7.v
+++ b/pm/misc/Lemma5_7.v
@@ -21,7 +21,7 @@ Proof.
   2: {
     pose proof (n4_32 (P ↔ Q) (P ↔ R) (R ↔ S)) as n4_32a.
     apply propositional_extensionality.
-    symmetry in n4_32a.
+    rewrite -> n4_21 in n4_32a.
     exact n4_32a.
   }
   replace ((P ↔ R) ∧ (R ↔ S)) with ((R ↔ S) ∧ (P ↔ R)) in Imp3_31a

--- a/pm/misc/Lemma5_7.v
+++ b/pm/misc/Lemma5_7.v
@@ -11,7 +11,7 @@ Proof.
   pose proof (n4_22 Q R S) as n4_22b.
   pose proof (Exp3_3 (Q ↔ R) (R ↔ S) (Q ↔ S)) as Exp3_3a.
   MP Exp3_3a n4_22b.
-  Syll n4_22a Exp3_3a Sa.
+  Syll_as n4_22a Exp3_3a Sa.
   replace (Q ↔ P) with (P ↔ Q) in Sa by
     (apply propositional_extensionality; exact (n4_21 P Q)).
   pose proof (Imp3_31 ((P ↔ Q) ∧ (P ↔ R)) (R ↔ S) (Q ↔ S)) as Imp3_31a.

--- a/pm/misc/Nicod1_4.v
+++ b/pm/misc/Nicod1_4.v
@@ -8,10 +8,10 @@ Proof.
   pose proof (Assoc1_5 P Q P) as Assoc1_5a.
   pose proof (Sum1_6 P Q (Q ∨ P)) as Sum1_6a.
   MP Sum1_6a n2_2a.
-  Syll Sum1_6a Assoc1_5a Sa.
+  Syll_as Sum1_6a Assoc1_5a Sa.
   pose proof (Taut1_2 P) as Taut1_2a.
   pose proof (Sum1_6 Q (P ∨ P) P) as Sum1_6b.
   MP Sum1_6b Taut1_2a.
-  Syll Sa Sum1_6b Sb.
+  Syll_as Sa Sum1_6b Sb.
   exact Sb.
 Qed.

--- a/pm/misc/Yuelin.v
+++ b/pm/misc/Yuelin.v
@@ -12,7 +12,7 @@ Proof.
     pose proof (Fact3_45 P R Q) as Fact3_45a. (*Yuelin's book has n2_45. Fact3_45 is meant.*)
     replace (R ∧ Q) with (Q ∧ R) in Fact3_45a
       by (apply propositional_extensionality; exact (n4_3 Q R)).
-    Syll Simp3_26a Fact3_45a Sa. (*Syll2_05*)
+    Syll_as Simp3_26a Fact3_45a Sa. (*Syll2_05*)
     exact Sa.
   }
   assert (Sb : (P → R) ∧ (Q → S) → Q ∧ R → R ∧ S).
@@ -21,13 +21,13 @@ Proof.
     pose proof (Fact3_45 Q S R) as Fact3_45b. (*Yuelin's book has n2_45. Fact3_45 is meant.*)
     replace (S ∧ R) with (R ∧ S) in Fact3_45b
       by (apply propositional_extensionality; exact (n4_3 R S)).
-    Syll Simp3_27a Fact3_45b Sb. (*Syll2_05*)
+    Syll_as Simp3_27a Fact3_45b Sb. (*Syll2_05*)
     exact Sb.
   }
-  Conj Sa Sb H.
+  Conj_as Sa Sb H.
   pose proof (Comp3_43 ((P → R) ∧ (Q → S)) ((P ∧ Q) → (Q ∧ R)) ((Q ∧ R) → (R ∧ S))) as Comp3_43a. (*Yuelin's book has n2_39. Comp3_43 is meant. PM and I have n2_83 here.*)
   MP Comp3_43a H.
   pose proof (Syll3_33 (P ∧ Q) (Q ∧ R) (R ∧ S)) as Syll3_33a. (*Yuelin's book has n2_39. Syll3_33 is meant. My n2_83 does this work, too.*)
-  Syll Comp3_43a Syll3_33a Sc. (*Yuelin seems to do another application of Syll3_33, citing the same number n2_39. But that would also require here, as above, Conjunction, which Yuelin does not bother citing.*)
+  Syll_as Comp3_43a Syll3_33a Sc. (*Yuelin seems to do another application of Syll3_33, citing the same number n2_39. But that would also require here, as above, Conjunction, which Yuelin does not bother citing.*)
   exact Sc.
 Qed.


### PR DESCRIPTION
This PR:
- Redesigns `MP` so that it matches exactly the hypothesis
- Redesigns other tactics in similar flavor
- Corrects proofs that use these Ltacs
- Removes a lot of `clear`s from both documentation and proofs
- Removes related `assert` blocks that were to ensure performing the `Ltac`s correctly. It turns out that even they are unable to ensure 100% correctness
- Removes `symmetry` tactic

This automatically makes #24 trivial to be implemented