### PR TITLE
Dagaz ch2

### DIFF
--- a/pm/dagaz/ch2.v
+++ b/pm/dagaz/ch2.v
@@ -103,8 +103,10 @@ Proof.
   assert (S1 : ¬ P ∨ P → P ∨ ¬ P).
   { exact (Perm1_4 (¬ P) P). }
   assert (S2 : P ∨ ¬P ).
-  { pose proof (n2_1 P) as n2_1.
-   now MP S1 n2_1. }
+  { 
+    pose proof (n2_1 P) as n2_1.
+    now MP S1 n2_1. 
+  }
   exact S2.
 Qed.
 
@@ -128,8 +130,10 @@ Proof.
   assert (S3 : P ∨ ¬ P → P ∨ ¬¬¬ P).
   { now MP S1 S2. }
   assert (S4 : P ∨ ¬¬¬ P).
-  { pose proof (n2_11 P) as n2_11.
-  now MP S3 n2_11. }
+  { 
+    pose proof (n2_11 P) as n2_11.
+    now MP S3 n2_11. 
+  }
   exact S4.
 Qed.
 
@@ -140,7 +144,8 @@ Proof.
   { exact (Perm1_4 P (¬¬¬ P)). }
   assert (S2 : ¬¬¬ P ∨ P).
   { pose proof (n2_13 P) as n2_13.
-   now MP S1 n2_13. }
+    now MP S1 n2_13. 
+  }
   assert (S3 : ¬¬ P → P).
   { now rewrite <- Impl1_01 in S2. }
   exact S3.

--- a/pm/dagaz/ch2.v
+++ b/pm/dagaz/ch2.v
@@ -66,7 +66,9 @@ Qed.
 Theorem n2_07 (P : Prop) :
   P → (P ∨ P).
 Proof.
-  exact (Add1_3 P P).
+  assert (S1 : P → (P ∨ P)).
+  { exact (Add1_3 P P). }
+  exact S1.
 Qed.
 
 Theorem Id2_08 (P : Prop) :
@@ -101,11 +103,10 @@ Theorem n2_11 (P : Prop) :
 Proof.
   assert (S1 : ¬ P ∨ P → P ∨ ¬ P).
   { exact (Perm1_4 (¬ P) P). }
-  assert (S2 : ¬ P ∨ P).
-  { exact (n2_1 P). }
-  assert (S3 : P ∨ ¬ P).
-  { now MP S1 S2. }
-  exact S3.
+  assert (S2 : P ∨ ¬P ).
+  { pose proof (n2_1 P) as n2_1.
+    now MP S1 n2_1. }
+  exact S2.
 Qed.
 
 Theorem n2_12 (P : Prop) :
@@ -127,11 +128,10 @@ Proof.
   { exact (n2_12 (¬ P)). }
   assert (S3 : P ∨ ¬ P → P ∨ ¬¬¬ P).
   { now MP S1 S2. }
-  assert (S4 : P ∨ ¬ P).
-  { exact (n2_11 P). }
-  assert (S5 : P ∨ ¬¬¬ P).
-  { now MP S3 S4. }
-  exact S5.
+  assert (S4 : P ∨ ¬¬¬ P).
+  { pose proof (n2_11 P) as n2_11.
+  now MP S3 n2_11. }
+  exact S4.
 Qed.
 
 Theorem n2_14 (P : Prop) :
@@ -139,13 +139,12 @@ Theorem n2_14 (P : Prop) :
 Proof.
   assert (S1 : P ∨ ¬¬¬ P → ¬¬¬ P ∨ P).
   { exact (Perm1_4 P (¬¬¬ P)). }
-  assert (S2 : P ∨ ¬¬¬ P).
-  { exact (n2_13 P). }
-  assert (S3 : ¬¬¬ P ∨ P).
-  { now MP S1 S2. }
-  assert (S4 : ¬¬ P → P).
-  { now rewrite <- Impl1_01 in S3. }
-  exact S4.
+  assert (S2 : ¬¬¬ P ∨ P).
+  { pose proof (n2_13 P) as n2_13.
+   now MP S1 n2_13. }
+  assert (S3 : ¬¬ P → P).
+  { now rewrite <- Impl1_01 in S2. }
+  exact S3.
 Qed.
 
 Theorem Transp2_15 (P Q : Prop) :
@@ -163,8 +162,8 @@ Proof.
   { exact (Syll2_05 (¬ Q) (¬ (¬ P)) P). }
   assert (S6 : (¬ Q → ¬ (¬ P)) → (¬ Q → P)).
   {
-    pose proof (n2_14 P) as H14.
-    now MP S5 H14.
+    pose proof (n2_14 P) as n2_14.
+    now MP S5 n2_14.
   }
   assert (S7 : ((¬ P → ¬ (¬ Q)) → (¬ Q → ¬ (¬ P))) → 
                (((¬ P → Q) → (¬ P → ¬ (¬ Q))) → ((¬ P → Q) → (¬ Q → ¬ (¬ P))))).
@@ -215,8 +214,7 @@ Proof.
   }
   assert (S3 : (P → ¬¬ Q) → (¬ Q → ¬ P)).
   { exact (Transp2_03 P (¬ Q)). }
-  assert (S4 : (P → Q) → (¬ Q → ¬ P)).
-  { now Syll_as S2 S3 S4. }
+  Syll_as S2 S3 S4.
   exact S4.
 Qed.
 
@@ -232,8 +230,7 @@ Proof.
     pose proof (Syll2_05 P (¬¬ Q) Q) as Syll2_05.
     now MP Syll2_05 S2.
   }
-  assert (S4 : (¬ Q → ¬ P) → (P → Q)).
-  { now Syll_as S1 S3 S4. }
+  Syll_as S1 S3 S4.
   exact S4.
 Qed.
 
@@ -249,12 +246,10 @@ Proof.
   }
   assert (S3 : (¬ P → ¬¬ P) → ¬¬ P).
   { exact (Abs2_01 (¬ P)). }
-  assert (S4 : (¬ P → P) → ¬¬ P).
-  { now Syll_as S2 S3 S4. }
+  Syll_as S2 S3 S4.
   assert (S5 : ¬¬ P → P).
   { exact (n2_14 P). }
-  assert (S6 : (¬ P → P) → P).
-  { now Syll_as S4 S5 S6. }
+  Syll_as S4 S5 S6.
   exact S6.
 Qed.
 
@@ -265,8 +260,7 @@ Proof.
   { exact (Add1_3 Q P). }
   assert (S2 : Q ∨ P → P ∨ Q).
   { exact (Perm1_4 Q P). }
-  assert (S3 : P → P ∨ Q).
-  { now Syll_as S1 S2 S3. }
+  Syll_as S1 S2 S3.
   exact S3.
 Qed.
 
@@ -295,26 +289,29 @@ Qed.
 Theorem n2_25 (P Q : Prop) :
   P ∨ ((P ∨ Q) → Q).
 Proof.
+  (* TOOLS *)
+  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
+  (* ******** *)
   assert (S1 : ¬ (P ∨ Q) ∨ (P ∨ Q)).
   { exact (n2_1 (P ∨ Q)). }
-  assert (S2 : ¬ (P ∨ Q) ∨ (P ∨ Q) → P ∨ ¬ (P ∨ Q) ∨ Q).
-  { exact (Assoc1_5 (¬ (P ∨ Q)) P Q). }
-  assert (S3 : P ∨ ¬ (P ∨ Q) ∨  Q).
-  { now MP S2 S1. }
-  assert (S4 : P ∨ ((P ∨ Q) → Q)).
-  { now repeat rewrite <- Impl1_01 in S3. }
-  exact S4.
+  assert (S2 : P ∨ (¬ (P ∨ Q) ∨ Q)).
+  {
+    pose proof (Assoc1_5 (¬ (P ∨ Q)) P Q) as Assoc1_5.
+    now MP Assoc1_5 S1.
+  }
+  assert (S3 : P ∨ ((P ∨ Q) → Q)).
+  { now rewrite <- (Impl1_01a (P ∨ Q) Q) in S2. }
+  exact S3.
 Qed.
 
 Theorem n2_26 (P Q : Prop) :
   ¬ P ∨ ((P → Q) → Q).
 Proof.
+  (* TOOLS *)
+  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
+  (* ******** *)
   assert (S1 : ¬ P ∨ ((¬ P ∨ Q) → Q)).
   { exact (n2_25 (¬ P) Q). }
-
-  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0))
-    as Impl1_01a.
-    
   assert (S2 : ¬ P ∨ ((P → Q) → Q)).
   { now rewrite <- (Impl1_01a P Q) in S1. }
   exact S2.
@@ -335,11 +332,12 @@ Theorem n2_3 (P Q R : Prop) :
 Proof.
   assert (S1 : Q ∨ R → R ∨ Q).
   { exact (Perm1_4 Q R). }
-  assert (S2 : (Q ∨ R → R ∨ Q) → (P ∨ (Q ∨ R) → P ∨ (R ∨ Q))).
-  { exact (Sum1_6 P (Q ∨ R) (R ∨ Q)). }
-  assert (S3 : P ∨ (Q ∨ R) → P ∨ (R ∨ Q)).
-  { now MP S2 S1. }
-  exact S3.
+  assert (S2 : P ∨ (Q ∨ R) → P ∨ (R ∨ Q)).
+  {
+    pose proof (Sum1_6 P (Q ∨ R) (R ∨ Q)) as Sum1_6.
+    now MP Sum1_6 S1.
+  }
+  exact S2.
 Qed.
 
 Theorem n2_31 (P Q R : Prop) :
@@ -347,15 +345,17 @@ Theorem n2_31 (P Q R : Prop) :
 Proof.
   assert (S1 : P ∨ (Q ∨ R) → P ∨ (R ∨ Q)).
   { exact (n2_3 P Q R). }
-  assert (S2 : P ∨ (R ∨ Q) → R ∨ (P ∨ Q)).
-  { exact (Assoc1_5 P R Q). }
-  assert (S3 : R ∨ (P ∨ Q) → (P ∨ Q) ∨ R).
-  { exact (Perm1_4 R (P ∨ Q)). }
-  assert (S4 : P ∨ (R ∨ Q) → (P ∨ Q) ∨ R).
-  { now Syll_as S2 S3 S4. }
-  assert (S5 : P ∨ (Q ∨ R) → ((P ∨ Q) ∨ R)).
-  { now Syll_as S1 S4 S5. }
-  exact S5.
+  assert (S2 : P ∨ (Q ∨ R) → R ∨ (P ∨ Q)).
+  {
+    pose proof (Assoc1_5 P R Q) as Assoc1_5.
+    now Syll_as S1 Assoc1_5 S2.
+  }
+  assert (S3 : P ∨ (Q ∨ R) → (P ∨ Q) ∨ R).
+  {
+    pose proof (Perm1_4 R (P ∨ Q)) as Perm1_4.
+    now Syll_as S2 Perm1_4 S3.
+  }
+  exact S3.
 Qed.
 
 Theorem n2_32 (P Q R : Prop) :
@@ -363,72 +363,54 @@ Theorem n2_32 (P Q R : Prop) :
 Proof.
   assert (S1 : (P ∨ Q) ∨ R → R ∨ (P ∨ Q)).
   { exact (Perm1_4 (P ∨ Q) R). }
-  assert (S2 : R ∨ (P ∨ Q) → P ∨ (R ∨ Q)).
-  { exact (Assoc1_5 R P Q). }
-  assert (S3 : P ∨ (R ∨ Q) → P ∨ (Q ∨ R)).
-  { exact (n2_3 P R Q). }
-  Syll_as S1 S2 S3_1.
-  now Syll_as S3_1 S3 S3_2.
+  assert (S2 : (P ∨ Q) ∨ R → P ∨ (R ∨ Q)).
+  {
+    pose proof (Assoc1_5 R P Q) as H.
+    now Syll_as S1 H S2.
+  }
+  assert (S3 : (P ∨ Q) ∨ R → P ∨ (Q ∨ R)).
+  {
+    pose proof (n2_3 P R Q) as n2_3.
+    now Syll_as S2 n2_3 S3.
+  }
+  exact S3.
 Qed.
 
-Theorem Abb2_33 (P Q R : Prop) :
+Definition Abb2_33 (P Q R : Prop) :
   (P ∨ Q ∨ R) = ((P ∨ Q) ∨ R).
 Admitted.
 
 Theorem n2_36 (P Q R : Prop) :
   (Q → R) → ((P ∨ Q) → (R ∨ P)).
 Proof.
-  assert (S1 : P ∨ R → R ∨ P).
-  { exact (Perm1_4 P R). }
-  assert (S2 : (P ∨ R → R ∨ P) → ((P ∨ Q → P ∨ R) → (P ∨ Q → R ∨ P))).
-  { exact (Syll2_05 (P ∨ Q) (P ∨ R) (R ∨ P)). }
-  assert (S3 : (P ∨ Q → P ∨ R) → (P ∨ Q → R ∨ P)).
-  { now MP S2 S1. }
-  assert (S4 : (Q → R) → (P ∨ Q → P ∨ R)).
+  assert (S1 : (P ∨ Q → P ∨ R) → (P ∨ Q → R ∨ P)).
+  { exact (Syll2_05 (P ∨ Q) (P ∨ R) (R ∨ P) (Perm1_4 P R)). }
+  assert (S2 : (Q → R) → (P ∨ Q → P ∨ R)).
   { exact (Sum1_6 P Q R). }
-  assert (S5 : (Q → R) → (P ∨ Q → R ∨ P)).
-  { now Syll_as S4 S3 S5. }
-  exact S5.
+  Syll_as S2 S1 S3.
+  exact S3.
 Qed.
 
 Theorem n2_37 (P Q R : Prop) :
   (Q → R) → ((Q ∨ P) → (P ∨ R)).
 Proof.
-  assert (S1 : Q ∨ P → P ∨ Q).
-  { exact (Perm1_4 Q P). }
-  assert (S2 : (Q ∨ P → P ∨ Q) → ((P ∨ Q → P ∨ R) → (Q ∨ P → P ∨ R))).
-  { exact (Syll2_06 (Q ∨ P) (P ∨ Q) (P ∨ R)). }
-  assert (S3 : (P ∨ Q → P ∨ R) → (Q ∨ P → P ∨ R)).
-  { now MP S2 S1. }
-  assert (S4 : (Q → R) → (P ∨ Q → P ∨ R)).
+  assert (S1 : (P ∨ Q → P ∨ R) → (Q ∨ P → P ∨ R)).
+  { exact (Syll2_06 (Q ∨ P) (P ∨ Q) (P ∨ R) (Perm1_4 Q P)). }
+  assert (S2 : (Q → R) → (P ∨ Q → P ∨ R)).
   { exact (Sum1_6 P Q R). }
-  assert (S5 : (Q → R) → (Q ∨ P → P ∨ R)).
-  { now Syll_as S4 S3 S5. }
-  exact S5.
+  Syll_as S2 S1 S3.
+  exact S3.
 Qed.
 
 Theorem n2_38 (P Q R : Prop) :
   (Q → R) → ((Q ∨ P) → (R ∨ P)).
 Proof.
-  assert (S1 : P ∨ R → R ∨ P).
-  { exact (Perm1_4 P R). }
-  assert (S2 : (P ∨ R → R ∨ P) → ((Q ∨ P → P ∨ R) → (Q ∨ P → R ∨ P))).
-  { exact (Syll2_05 (Q ∨ P) (P ∨ R) (R ∨ P)). }
-  assert (S3 : (Q ∨ P → P ∨ R) → (Q ∨ P → R ∨ P)).
-  { now MP S2 S1. }
-  assert (S4 : Q ∨ P → P ∨ Q).
-  { exact (Perm1_4 Q P). }
-  assert (S5 : (Q ∨ P → P ∨ Q) → ((P ∨ Q → P ∨ R) → (Q ∨ P → P ∨ R))).
-  { exact (Syll2_06 (Q ∨ P) (P ∨ Q) (P ∨ R)). }
-  assert (S6 : (P ∨ Q → P ∨ R) → (Q ∨ P → P ∨ R)).
-  { now MP S5 S4. }
-  assert (S7 : (P ∨ Q → P ∨ R) → (Q ∨ P → R ∨ P)).
-  { now Syll_as S6 S3 S7. }
-  assert (S8 : (Q → R) → (P ∨ Q → P ∨ R)).
-  { exact (Sum1_6 P Q R). }
-  assert (S9 : (Q → R) → (Q ∨ P → R ∨ P)).
-  { now Syll_as S8 S7 S9. }
-  exact S9.
+  assert (S1 : (Q → R) → (Q ∨ P → P ∨ R)).
+  { exact (n2_37 P Q R). }
+  assert (S2 : (Q ∨ P → P ∨ R) → (Q ∨ P → R ∨ P)).
+  { exact (Syll2_05 (Q ∨ P) (P ∨ R) (R ∨ P) (Perm1_4 P R)). }
+  Syll_as S1 S2 S3.
+  exact S3.
 Qed.
 
 Theorem n2_4 (P Q : Prop) :
@@ -436,15 +418,10 @@ Theorem n2_4 (P Q : Prop) :
 Proof.
   assert (S1 : P ∨ (P ∨ Q) → (P ∨ P) ∨ Q).
   { exact (n2_31 P P Q). }
-  assert (S2 : P ∨ P → P).
-  { exact (Taut1_2 P). }
-  assert (S3 : (P ∨ P → P) → ((P ∨ P) ∨ Q → P ∨ Q)).
-  { exact (n2_38 Q (P ∨ P) P). }
-  assert (S4 : (P ∨ P) ∨ Q → P ∨ Q).
-  { now MP S3 S2. }
-  assert (S5 : P ∨ (P ∨ Q) → P ∨ Q).
-  { now Syll_as S1 S4 S5. }
-  exact S5.
+  assert (S2 : (P ∨ P) ∨ Q → P ∨ Q).
+  { exact (n2_38 Q (P ∨ P) P (Taut1_2 P)). }
+  Syll_as S1 S2 S3.
+  exact S3.
 Qed.
 
 Theorem n2_41 (P Q : Prop) :
@@ -452,302 +429,252 @@ Theorem n2_41 (P Q : Prop) :
 Proof.
   assert (S1 : Q ∨ (P ∨ Q) → P ∨ (Q ∨ Q)).
   { exact (Assoc1_5 Q P Q). }
-  assert (S2 : Q ∨ Q → Q).
-  { exact (Taut1_2 Q). }
-  assert (S3 : (Q ∨ Q → Q) → (P ∨ (Q ∨ Q) → P ∨ Q)).
-  { exact (Sum1_6 P (Q ∨ Q) Q). }
-  assert (S4 : P ∨ (Q ∨ Q) → P ∨ Q).
-  { now MP S3 S2. }
-  assert (S5 : Q ∨ (P ∨ Q) → P ∨ Q).
-  { now Syll_as S1 S4 S5. }
-  exact S5.
+  assert (S2 : P ∨ (Q ∨ Q) → P ∨ Q).
+  { exact (Sum1_6 P (Q ∨ Q) Q (Taut1_2 Q)). }
+  Syll_as S1 S2 S3.
+  exact S3.
 Qed.
 
 Theorem n2_42 (P Q : Prop) :
   (¬ P ∨ (P → Q)) → (P → Q).
 Proof.
+  (* TOOLS *)
+  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
+  (* ******** *)
   assert (S1 : ¬ P ∨ (¬ P ∨ Q) → ¬ P ∨ Q).
   { exact (n2_4 (¬ P) Q). }
-  assert (S2 : ¬ P ∨ (P → Q) → (P → Q)).
-  { now repeat rewrite <- (Impl1_01 P Q) in S1. }
+  assert (S2 : (¬ P ∨ (P → Q)) → (P → Q)).
+  { now rewrite <- (Impl1_01a P Q) in S1. }
   exact S2.
 Qed.
 
 Theorem n2_43 (P Q : Prop) :
   (P → (P → Q)) → (P → Q).
 Proof.
+  (* TOOLS *)
+  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
+  (* ******** *)
   assert (S1 : ¬ P ∨ (P → Q) → (P → Q)).
   { exact (n2_42 P Q). }
   assert (S2 : (P → (P → Q)) → (P → Q)).
-  { now repeat rewrite <- Impl1_01 in S1. }
+  { now rewrite <- (Impl1_01a P (P → Q)) in S1. }
   exact S2.
 Qed.
 
 Theorem n2_45 (P Q : Prop) :
   ¬ (P ∨ Q) → ¬ P.
 Proof.
-  assert (S1 : P → P ∨ Q).
-  { exact (n2_2 P Q). }
-  assert (S2 : (P → P ∨ Q) → (¬ (P ∨ Q) → ¬ P)).
-  { exact (Transp2_16 P (P ∨ Q)). }
-  assert (S3 : ¬ (P ∨ Q) → ¬ P).
-  { now MP S2 S1. }
-  exact S3.
+  assert (S1 : ¬ (P ∨ Q) → ¬ P).
+  { exact (Transp2_16 P (P ∨ Q) (n2_2 P Q)). }
+  exact S1.
 Qed.
 
 Theorem n2_46 (P Q : Prop) :
   ¬ (P ∨ Q) → ¬ Q.
 Proof.
-  assert (S1 : Q → P ∨ Q).
-  { exact (Add1_3 P Q). }
-  assert (S2 : (Q → P ∨ Q) → (¬ (P ∨ Q) → ¬ Q)).
-  { exact (Transp2_16 Q (P ∨ Q)). }
-  assert (S3 : ¬ (P ∨ Q) → ¬ Q).
-  { now MP S2 S1. }
-  exact S3.
+  assert (S1 : ¬ (P ∨ Q) → ¬ Q).
+  { exact (Transp2_16 Q (P ∨ Q) (Add1_3 P Q)). }
+  exact S1.
 Qed.
 
 Theorem n2_47 (P Q : Prop) :
   ¬ (P ∨ Q) → (¬ P ∨ Q).
 Proof.
-  assert (S1 : ¬ (P ∨ Q) → ¬ P).
-  { exact (n2_45 P Q). }
-  assert (S2 : ¬ P → ¬ P ∨ Q).
-  { exact (n2_2 (¬ P) Q). }
-  assert (S3 : ¬ (P ∨ Q) → ¬ P ∨ Q).
-  { now Syll_as S1 S2 S3. }
-  exact S3.
+  assert (S1 : ¬ (P ∨ Q) → (¬ P ∨ Q)).
+  { exact (Syll2_05 (¬ (P ∨ Q)) (¬ P) (¬ P ∨ Q) (n2_2 (¬ P) Q) (n2_45 P Q)). }
+  exact S1.
 Qed.
 
 Theorem n2_48 (P Q : Prop) :
   ¬ (P ∨ Q) → (P ∨ ¬ Q).
 Proof.
-  assert (S1 : ¬ (P ∨ Q) → ¬ Q).
-  { exact (n2_46 P Q). }
-  assert (S2 : ¬ Q → P ∨ ¬ Q).
-  { exact (Add1_3 P (¬ Q)). }
-  assert (S3 : ¬ (P ∨ Q) → P ∨ ¬ Q).
-  { now Syll_as S1 S2 S3. }
-  exact S3.
+  assert (S1 : ¬ (P ∨ Q) → (P ∨ ¬ Q)).
+  { exact (Syll2_06 (¬ (P ∨ Q)) (¬ Q) (P ∨ ¬ Q) (n2_46 P Q) (Add1_3 P (¬ Q))). }
+  exact S1.
 Qed.
 
 Theorem n2_49 (P Q : Prop) :
   ¬ (P ∨ Q) → (¬ P ∨ ¬ Q).
 Proof.
-  assert (S1 : ¬ (P ∨ Q) → ¬ P).
-  { exact (n2_45 P Q). }
-  assert (S2 : ¬ P → ¬ P ∨ ¬ Q).
-  { exact (n2_2 (¬ P) (¬ Q)). }
-  assert (S3 : ¬ (P ∨ Q) → ¬ P ∨ ¬ Q).
-  { now Syll_as S1 S2 S3. }
-  exact S3.
+  assert (S1 : ¬ (P ∨ Q) → (¬ P ∨ ¬ Q)).
+  { exact (Syll2_06 (¬ (P ∨ Q)) (¬ P) (¬ P ∨ ¬ Q) (n2_45 P Q) (n2_2 (¬ P) (¬ Q))). }
+  exact S1.
 Qed.
 
 Theorem n2_5 (P Q : Prop) :
   ¬ (P → Q) → (¬ P → Q).
 Proof.
-  assert (S1 : ¬ (¬ P ∨ Q) → ¬ (¬ P) ∨ Q).
+  (* TOOLS *)
+  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
+  (* ******** *)
+  assert (S1 : ¬ (¬ P ∨ Q) → (¬ (¬ P) ∨ Q)).
   { exact (n2_47 (¬ P) Q). }
   assert (S2 : ¬ (P → Q) → (¬ P → Q)).
-  { now repeat rewrite <- Impl1_01 in S1. }
+  {
+    rewrite <- (Impl1_01a P Q) in S1.
+    now rewrite <- (Impl1_01a (¬ P) Q) in S1.
+  }
   exact S2.
 Qed.
 
 Theorem n2_51 (P Q : Prop) :
   ¬ (P → Q) → (P → ¬ Q).
 Proof.
-  assert (S1 : ¬ (¬ P ∨ Q) → ¬ P ∨ ¬ Q).
+  (* TOOLS *)
+  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
+  (* ******** *)
+  assert (S1 : ¬ (¬ P ∨ Q) → (¬ P ∨ ¬ Q)).
   { exact (n2_48 (¬ P) Q). }
   assert (S2 : ¬ (P → Q) → (P → ¬ Q)).
-  { now repeat rewrite <- Impl1_01 in S1. }
+  {
+    rewrite <- (Impl1_01a P Q) in S1.
+    now rewrite <- (Impl1_01a P (¬ Q)) in S1.
+  }
   exact S2.
 Qed.
 
 Theorem n2_52 (P Q : Prop) :
   ¬ (P → Q) → (¬ P → ¬ Q).
 Proof.
-  assert (S1 : ¬ (¬ P ∨ Q) → ¬ (¬ P) ∨ ¬ Q).
+  (* TOOLS *)
+  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
+  (* ******** *)
+  assert (S1 : ¬ (¬ P ∨ Q) → (¬ (¬ P) ∨ ¬ Q)).
   { exact (n2_49 (¬ P) Q). }
   assert (S2 : ¬ (P → Q) → (¬ P → ¬ Q)).
-  { now repeat rewrite <- Impl1_01 in S1. }
+  {
+    rewrite <- (Impl1_01a (¬ P) (¬ Q)) in S1.
+    now rewrite <- (Impl1_01a P Q) in S1.
+  }
   exact S2.
 Qed.
 
 Theorem n2_521 (P Q : Prop) :
   ¬ (P → Q) → (Q → P).
 Proof.
-  assert (S1 : ¬ (P → Q) → (¬ P → ¬ Q)).
-  { exact (n2_52 P Q). }
-  assert (S2 : (¬ P → ¬ Q) → (Q → P)).
-  { exact (Transp2_17 Q P). }
-  assert (S3 : ¬ (P → Q) → (Q → P)).
-  { now Syll_as S1 S2 S3. }
-  exact S3.
+  assert (S1 : ¬ (P → Q) → (Q → P)).
+  { exact (Syll2_06 (¬ (P → Q)) (¬ P → ¬ Q) (Q → P) (n2_52 P Q) (Transp2_17 Q P)). }
+  exact S1.
 Qed.
 
 Theorem n2_53 (P Q : Prop) :
   (P ∨ Q) → (¬ P → Q).
 Proof.
-  assert (S1 : P → ¬¬ P).
-  { exact (n2_12 P). }
-  assert (S2 : (P → ¬¬ P) → (P ∨ Q → ¬¬ P ∨ Q)).
-  { exact (n2_38 Q P (¬¬ P)). }
-  assert (S3 : P ∨ Q → ¬¬ P ∨ Q).
-  { now MP S2 S1. }
-  
-  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0))
-    as Impl1_01a.
-  
-  assert (S4 : P ∨ Q → (¬ P → Q)).
-  { now rewrite <- (Impl1_01a (¬ P) Q) in S3. }
-  exact S4.
+  (* TOOLS *)
+  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
+  (* ******** *)
+  assert (S1 : P ∨ Q → ¬¬ P ∨ Q).
+  { exact (n2_38 Q P (¬¬ P) (n2_12 P)). }
+  assert (S2 : (P ∨ Q) → (¬ P → Q)).
+  { now rewrite <- (Impl1_01a (¬ P) Q) in S1. }
+  exact S2.
 Qed.
 
 Theorem n2_54 (P Q : Prop) :
   (¬ P → Q) → (P ∨ Q).
 Proof.
-  assert (S1 : ¬¬ P → P).
-  { exact (n2_14 P). }
-  assert (S2 : (¬¬ P → P) → (¬¬ P ∨ Q → P ∨ Q)).
-  { exact (n2_38 Q (¬¬ P) P). }
-  assert (S3 : ¬¬ P ∨ Q → P ∨ Q).
-  { now MP S2 S1. }
-  
-  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0))
-    as Impl1_01a.
-  
-  assert (S4 : (¬ P → Q) → P ∨ Q).
-  { now rewrite <-(Impl1_01a (¬ P) Q) in S3. }
-  exact S4.
+  (* TOOLS *)
+  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
+  (* ******** *)
+  assert (S1 : ¬¬ P ∨ Q → P ∨ Q).
+  { exact (n2_38 Q (¬¬ P) P (n2_14 P)). }
+  assert (S2 : (¬ P → Q) → (P ∨ Q)).
+  { now rewrite <- (Impl1_01a (¬ P) Q) in S1. }
+  exact S2.
 Qed.
 
 Theorem n2_55 (P Q : Prop) :
   ¬ P → ((P ∨ Q) → Q).
 Proof.
-  assert (S1 : P ∨ Q → (¬ P → Q)).
-  { exact (n2_53 P Q). }
-  assert (S2 : (P ∨ Q → (¬ P → Q)) → (¬ P → (P ∨ Q → Q))).
-  { exact (Comm2_04 (P ∨ Q) (¬ P) Q). }
-  assert (S3 : ¬ P → (P ∨ Q → Q)).
-  { now MP S2 S1. }
-  exact S3.
+  assert (S1 : ¬ P → ((P ∨ Q) → Q)).
+  { exact (Comm2_04 (P ∨ Q) (¬ P) Q (n2_53 P Q)). }
+  exact S1.
 Qed.
 
 Theorem n2_56 (P Q : Prop) :
   ¬ Q → ((P ∨ Q) → P).
 Proof.
-  assert (S1 : ¬ Q → (Q ∨ P → P)).
-  { exact (n2_55 Q P). }
-  assert (S2 : P ∨ Q → Q ∨ P).
-  { exact (Perm1_4 P Q). }
-  assert (S3 : (P ∨ Q → Q ∨ P) → ((Q ∨ P → P) → (P ∨ Q → P))).
-  { exact (Syll2_06 (P ∨ Q) (Q ∨ P) P). }
-  assert (S4 : (Q ∨ P → P) → (P ∨ Q → P)).
-  { now MP S3 S2. }
-  Syll_as S1 S4 S5.
-  exact S5.
+  assert (S1 : ¬ Q → ((P ∨ Q) → P)).
+  { exact (Syll2_06 (¬ Q) (Q ∨ P → P) (P ∨ Q → P) (n2_55 Q P) (Syll2_06 (P ∨ Q) (Q ∨ P) P (Perm1_4 P Q))). }
+  exact S1.
 Qed.
 
 Theorem n2_6 (P Q : Prop) :
   (¬ P → Q) → ((P → Q) → Q).
 Proof.
+  (* TOOLS *)
+  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
+  (* ******** *)
   assert (S1 : (¬ P → Q) → (¬ P ∨ Q → Q ∨ Q)).
   { exact (n2_38 Q (¬ P) Q). }
-  assert (S2 : Q ∨ Q → Q).
-  { exact (Taut1_2 Q). }
-  assert (S3 : (Q ∨ Q → Q) → ((¬ P ∨ Q → Q ∨ Q) → (¬ P ∨ Q → Q))).
-  { exact (Syll2_05 (¬ P ∨ Q) (Q ∨ Q) Q). }
-  assert (S4 : (¬ P ∨ Q → Q ∨ Q) → (¬ P ∨ Q → Q)).
-  { now MP S3 S2. }
-  Syll_as S1 S4 S5.
-  
-  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0))
-    as Impl1_01a.
-  
-  assert (S6 : (¬ P → Q) → ((P → Q) → Q)).
-  { now rewrite <- (Impl1_01a P Q) in S5. }
-  exact S6.
+  assert (S2 : (¬ P ∨ Q → Q ∨ Q) → (¬ P ∨ Q → Q)).
+  { exact (Syll2_05 (¬ P ∨ Q) (Q ∨ Q) Q (Taut1_2 Q)). }
+  assert (S3 : (¬ P → Q) → (¬ P ∨ Q → Q)).
+  { exact (Syll2_06 (¬ P → Q) (¬ P ∨ Q → Q ∨ Q) (¬ P ∨ Q → Q) S1 S2). }
+  assert (S4 : (¬ P → Q) → ((P → Q) → Q)).
+  { now rewrite <- (Impl1_01a P Q) in S3. }
+  exact S4.
 Qed.
 
 Theorem n2_61 (P Q : Prop) :
   (P → Q) → ((¬ P → Q) → Q).
 Proof.
-  assert (S1 : (¬ P → Q) → ((P → Q) → Q)).
-  { exact (n2_6 P Q). }
-  assert (S2 : ((¬ P → Q) → ((P → Q) → Q)) → ((P → Q) → ((¬ P → Q) → Q))).
-  { exact (Comm2_04 (¬ P → Q) (P → Q) Q). }
-  assert (S3 : (P → Q) → ((¬ P → Q) → Q)).
-  { now MP S2 S1. }
-  exact S3.
+  assert (S1 : (P → Q) → ((¬ P → Q) → Q)).
+  { exact (Comm2_04 (¬ P → Q) (P → Q) Q (n2_6 P Q)). }
+  exact S1.
 Qed.
 
 Theorem n2_62 (P Q : Prop) :
   (P ∨ Q) → ((P → Q) → Q).
 Proof.
-  assert (S1 : P ∨ Q → (¬ P → Q)).
-  { exact (n2_53 P Q). }
-  assert (S2 : (¬ P → Q) → ((P → Q) → Q)).
-  { exact (n2_6 P Q). }
-  Syll_as S1 S2 S3.
-  exact S3.
+  assert (S1 : (P ∨ Q) → ((P → Q) → Q)).
+  { exact (Syll2_06 (P ∨ Q) (¬ P → Q) ((P → Q) → Q) (n2_53 P Q) (n2_6 P Q)). }
+  exact S1.
 Qed.
 
 Theorem n2_621 (P Q : Prop) :
   (P → Q) → ((P ∨ Q) → Q).
 Proof.
-  assert (S1 : P ∨ Q → ((P → Q) → Q)).
-  { exact (n2_62 P Q). }
-  assert (S2 : (P ∨ Q → ((P → Q) → Q)) → ((P → Q) → (P ∨ Q → Q))).
-  { exact (Comm2_04 (P ∨ Q) (P → Q) Q). }
-  assert (S3 : (P → Q) → (P ∨ Q → Q)).
-  { now MP S2 S1. }
-  exact S3.
+  assert (S1 : (P → Q) → ((P ∨ Q) → Q)).
+  { exact (Comm2_04 (P ∨ Q) (P → Q) Q (n2_62 P Q)). }
+  exact S1.
 Qed.
 
 Theorem n2_63 (P Q : Prop) :
   (P ∨ Q) → ((¬ P ∨ Q) → Q).
 Proof.
-  assert (S1 : P ∨ Q → ((P → Q) → Q)).
+  (* TOOLS *)
+  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
+  (* ******** *)
+  assert (S1 : (P ∨ Q) → ((P → Q) → Q)).
   { exact (n2_62 P Q). }
-  
-  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0))
-    as Impl1_01a.
-  
-  assert (S2 : P ∨ Q → (¬ P ∨ Q → Q)).
+  assert (S2 : (P ∨ Q) → ((¬ P ∨ Q) → Q)).
   { now rewrite (Impl1_01a P Q) in S1. }
   exact S2.
 Qed.
 
-
 Theorem n2_64 (P Q : Prop) :
   (P ∨ Q) → ((P ∨ ¬ Q) → P).
 Proof.
-  assert (S1 : Q ∨ P → (¬ Q ∨ P → P)).
-  { exact (n2_63 Q P). }
-  assert (S2 : P ∨ Q → Q ∨ P).
-  { exact (Perm1_4 P Q). }
-  Syll_as S2 S1 S3.
-  assert (S4 : P ∨ ¬ Q → ¬ Q ∨ P).
-  { exact (Perm1_4 P (¬ Q)). }
-  assert (S5 : (P ∨ ¬ Q → ¬ Q ∨ P) → ((¬ Q ∨ P → P) → (P ∨ ¬ Q → P))).
-  { exact (Syll2_06 (P ∨ ¬ Q) (¬ Q ∨ P) P). }
-  assert (S6 : (¬ Q ∨ P → P) → (P ∨ ¬ Q → P)).
-  { now MP S5 S4. }
-  Syll_as S3 S6 S7.
-  exact S7.
+  assert (S1 : (¬ Q ∨ P → P) → (P ∨ ¬ Q → P)).
+  { exact (Syll2_06 (P ∨ ¬ Q) (¬ Q ∨ P) P (Perm1_4 P (¬ Q))). }
+  assert (S2 : Q ∨ P → P ∨ ¬ Q → P).
+  { exact (Syll2_06 (Q ∨ P) (¬ Q ∨ P → P) (P ∨ ¬ Q → P) (n2_63 Q P) S1). }
+  assert (S3 : (P ∨ Q) → ((P ∨ ¬ Q) → P)).
+  { exact (Syll2_06 (P ∨ Q) (Q ∨ P) (P ∨ ¬ Q → P) (Perm1_4 P Q) S2). }
+  exact S3.
 Qed.
 
 Theorem n2_65 (P Q : Prop) :
   (P → Q) → ((P → ¬ Q) → ¬ P).
 Proof.
-  assert (S1 : ¬ P ∨ Q → (¬ P ∨ ¬ Q → ¬ P)).
+  (* TOOLS *)
+  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
+  (* ******** *)
+  assert (S1 : (¬ P ∨ Q) → ((¬ P ∨ ¬ Q) → ¬ P)).
   { exact (n2_64 (¬ P) Q). }
-  
-  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0))
-    as Impl1_01a.
-  
-  assert (S2 : (P → Q) → (P → ¬ Q) → ¬ P).
-  { 
+  assert (S2 : (P → Q) → ((P → ¬ Q) → ¬ P)).
+  {
     rewrite <- (Impl1_01a P Q) in S1.
     now rewrite <- (Impl1_01a P (¬ Q)) in S1.
   }
@@ -757,40 +684,29 @@ Qed.
 Theorem n2_67 (P Q : Prop) :
   ((P ∨ Q) → Q) → (P → Q).
 Proof.
-  assert (S1 : (¬ P → Q) → P ∨ Q).
-  { exact (n2_54 P Q). }
-  assert (S2 : ((¬ P → Q) → P ∨ Q) → ((P ∨ Q → Q) → ((¬ P → Q) → Q))).
-  { exact (Syll2_06 (¬ P → Q) (P ∨ Q) Q). }
-  assert (S3 : (P ∨ Q → Q) → ((¬ P → Q) → Q)).
-  { now MP S2 S1. }
-  assert (S4 : P → (¬ P → Q)).
-  { exact (n2_24 P Q). }
-  assert (S5 : (P → (¬ P → Q)) → (((¬ P → Q) → Q) → (P → Q))).
-  { exact (Syll2_06 P (¬ P → Q) Q). }
-  assert (S6 : ((¬ P → Q) → Q) → (P → Q)).
-  { now MP S5 S4. }
-  Syll_as S3 S6 S7.
-  exact S7.
+  assert (S1 : ((P ∨ Q) → Q) → ((¬ P → Q) → Q)).
+  { exact (Syll2_06 (¬ P → Q) (P ∨ Q) Q (n2_54 P Q)). }
+  assert (S2 : ((¬ P → Q) → Q) → (P → Q)).
+  { exact (Syll2_06 P (¬ P → Q) Q (n2_24 P Q)). }
+  Syll_as S1 S2 S3.
+  exact S3.
 Qed.
-
 
 Theorem n2_68 (P Q : Prop) :
   ((P → Q) → Q) → (P ∨ Q).
 Proof.
-  assert (S1 : (¬ P ∨ Q → Q) → (¬ P → Q)).
+  (* TOOLS *)
+  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
+  (* ******** *)
+  assert (S1 : ((¬ P ∨ Q) → Q) → (¬ P → Q)).
   { exact (n2_67 (¬ P) Q). }
-  
-  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0))
-    as Impl1_01a.
-  
   assert (S2 : ((P → Q) → Q) → (¬ P → Q)).
   { now rewrite <- (Impl1_01a P Q) in S1. }
-  assert (S3 : (¬ P → Q) → P ∨ Q).
+  assert (S3 : (¬ P → Q) → (P ∨ Q)).
   { exact (n2_54 P Q). }
   Syll_as S2 S3 S4.
   exact S4.
 Qed.
-
 
 Theorem n2_69 (P Q : Prop) :
   ((P → Q) → Q) → ((Q → P) → P).
@@ -841,6 +757,9 @@ Qed.
 Theorem n2_75 (P Q R : Prop) :
   (P ∨ Q) → ((P ∨ (Q → R)) → (P ∨ R)).
 Proof.
+  (* TOOLS *)
+  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
+  (* ******** *)
   assert (S1 : (¬ Q → P) → ((P ∨ ¬ Q) ∨ R → P ∨ R)).
   { exact (n2_74 P (¬ Q) R). }
   assert (S2 : Q ∨ P → (¬ Q → P)).
@@ -856,11 +775,7 @@ Proof.
   assert (S8 : P ∨ Q → Q ∨ P).
   { exact (Perm1_4 P Q). }
   Syll_as S8 S7 S9.
-  
-  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0))
-    as Impl1_01a.
-  
-  assert (S10 : P ∨ Q → (P ∨ (Q → R) → P ∨ R)).
+  assert (S10 : (P ∨ Q) → (P ∨ (Q → R) → P ∨ R)).
   { now rewrite <- (Impl1_01a Q R) in S9. }
   exact S10.
 Qed.
@@ -880,13 +795,12 @@ Qed.
 Theorem n2_77 (P Q R : Prop) :
   (P → (Q → R)) → ((P → Q) → (P → R)).
 Proof.
+  (* TOOLS *)
+  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
+  (* ******** *)
   assert (S1 : ¬ P ∨ (Q → R) → (¬ P ∨ Q → ¬ P ∨ R)).
   { exact (n2_76 (¬ P) Q R). }
-  
-  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0))
-    as Impl1_01a.
-  
-  assert (S2 : (P → Q → R) → (P → Q) → (P → R)).
+  assert (S2 : (P → (Q → R)) → ((P → Q) → (P → R))).
   {
     rewrite <- (Impl1_01a P (Q → R)) in S1.
     rewrite <- (Impl1_01a P Q) in S1.
@@ -909,20 +823,16 @@ Proof.
   exact S5.
 Qed.
 
-
 Theorem n2_81 (P Q R S : Prop) :
   (Q → (R → S)) → ((P ∨ Q) → ((P ∨ R) → (P ∨ S))).
 Proof.
   assert (S1 : (Q → (R → S)) → (P ∨ Q → P ∨ (R → S))).
   { exact (Sum1_6 P Q (R → S)). }
-  assert (S2 : P ∨ (R → S) → (P ∨ R → P ∨ S)).
-  { exact (n2_76 P R S). }
-  assert (S3 : (P ∨ (R → S) → (P ∨ R → P ∨ S)) → ((P ∨ Q → P ∨ (R → S)) → (P ∨ Q → (P ∨ R → P ∨ S)))).
-  { exact (Syll2_05 (P ∨ Q) (P ∨ (R → S)) (P ∨ R → P ∨ S)). }
-  assert (S4 : (P ∨ Q → P ∨ (R → S)) → (P ∨ Q → (P ∨ R → P ∨ S))).
-  { now MP S3 S2. }
-  Syll_as S1 S4 S5.
-  exact S5.
+  assert (S2 : (P ∨ Q → P ∨ (R → S)) → (P ∨ Q → (P ∨ R → P ∨ S))).
+  { exact (Syll2_05 (P ∨ Q) (P ∨ (R → S)) (P ∨ R → P ∨ S) (n2_76 P R S)). }
+  assert (S3 : (Q → (R → S)) → ((P ∨ Q) → ((P ∨ R) → (P ∨ S)))).
+  { exact (Syll2_06 (Q → (R → S)) (P ∨ Q → P ∨ (R → S)) (P ∨ Q → (P ∨ R → P ∨ S)) S1 S2). }
+  exact S3.
 Qed.
 
 Theorem n2_82 (P Q R S : Prop) :
@@ -940,13 +850,12 @@ Qed.
 Theorem n2_83 (P Q R S : Prop) :
   (P → (Q → R)) → ((P → (R → S)) → (P → (Q → S))).
 Proof.
+  (* TOOLS *)
+  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
+  (* ******** *)
   assert (S1 : ¬ P ∨ (¬ Q ∨ R) → (¬ P ∨ (¬ R ∨ S) → ¬ P ∨ (¬ Q ∨ S))).
   { exact (n2_82 (¬ P) (¬ Q) R S). }
-  
-  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0))
-    as Impl1_01a.
-  
-  assert (S2 : (P → Q → R) → (P → R → S) → (P → Q → S)).
+  assert (S2 : (P → (Q → R)) → ((P → (R → S)) → (P → (Q → S)))).
   {
     rewrite <- (Impl1_01a Q R) in S1.
     rewrite <- (Impl1_01a P (Q → R)) in S1.
@@ -961,45 +870,32 @@ Qed.
 Theorem n2_85 (P Q R : Prop) :
   ((P ∨ Q) → (P ∨ R)) → (P ∨ (Q → R)).
 Proof.
-  assert (S1 : Q → P ∨ Q).
-  { exact (Add1_3 P Q). }
-  assert (S2 : (Q → P ∨ Q) → ((P ∨ Q → R) → (Q → R))).
-  { exact (Syll2_06 Q (P ∨ Q) R). }
-  assert (S3 : (P ∨ Q → R) → (Q → R)).
-  { now MP S2 S1. }
-  assert (S4 : ¬ P → (P ∨ R → R)).
-  { exact (n2_55 P R). }
-  assert (S5 : (P ∨ R → R) → ((P ∨ Q → P ∨ R) → (P ∨ Q → R))).
-  { exact (Syll2_05 (P ∨ Q) (P ∨ R) R). }
-  Syll_as S4 S5 S6.
-  assert (S7 : (¬ P → ((P ∨ Q → P ∨ R) → (P ∨ Q → R))) → ((¬ P → ((P ∨ Q → R) → (Q → R))) → (¬ P → ((P ∨ Q → P ∨ R) → (Q → R))))). 
-  { exact (n2_83 (¬ P) (P ∨ Q → P ∨ R) (P ∨ Q → R) (Q → R)). }
-  assert (S8 : (¬ P → ((P ∨ Q → R) → (Q → R))) → (¬ P → ((P ∨ Q → P ∨ R) → (Q → R)))).
-  { now MP S7 S6. }
-  assert (S9 : (¬ P → ((P ∨ Q → P ∨ R) → (Q → R))) → ((P ∨ Q → P ∨ R) → (¬ P → (Q → R)))). 
-  { exact (Comm2_04 (¬ P) (P ∨ Q → P ∨ R) (Q → R)). }
-  Syll_as S8 S9 S10.
-  assert (S11 : ((P ∨ Q → R) → (Q → R)) → (¬ P → ((P ∨ Q → R) → (Q → R)))).
-  { exact (Simp2_02 (¬ P) ((P ∨ Q → R) → (Q → R))). }
-  assert (S12 : ¬ P → ((P ∨ Q → R) → (Q → R))).
-  { now MP S11 S3. }
-  assert (S13 : (P ∨ Q → P ∨ R) → (¬ P → (Q → R))).
-  { now MP S10 S12. }
-  assert (S14 : (¬ P → (Q → R)) → P ∨ (Q → R)).
-  { exact (n2_54 P (Q → R)). }
-  Syll_as S13 S14 S15.
-  exact S15.
+  assert (S1 : (P ∨ Q → R) → (Q → R)).
+  { exact (Syll2_06 Q (P ∨ Q) R (Add1_3 P Q)). }
+  assert (S2 : ¬ P → ((P ∨ Q → P ∨ R) → (Q → R))).
+  {
+    pose proof (Syll2_05 (P ∨ Q → P ∨ R) (P ∨ Q → R) (Q → R) S1) as Syll2_05a.
+    pose proof (Syll2_06 (¬ P) (P ∨ R → R) ((P ∨ Q → P ∨ R) → (P ∨ Q → R)) (n2_55 P R) (Syll2_05 (P ∨ Q) (P ∨ R) R)) as Syll2_06a.
+    exact (Syll2_06 (¬ P) ((P ∨ Q → P ∨ R) → (P ∨ Q → R)) ((P ∨ Q → P ∨ R) → (Q → R)) Syll2_06a Syll2_05a).
+  }
+  assert (S3 : (P ∨ Q → P ∨ R) → (¬ P → (Q → R))).
+  { exact (Comm2_04 (¬ P) (P ∨ Q → P ∨ R) (Q → R) S2). }
+  assert (S4 : (P ∨ Q → P ∨ R) → (P ∨ (Q → R))).
+  {
+    pose proof (n2_54 P (Q → R)) as n2_54.
+    exact (Syll2_06 (P ∨ Q → P ∨ R) (¬ P → (Q → R)) (P ∨ (Q → R)) S3 n2_54).
+  }
+  exact S4.
 Qed.
     
 Theorem n2_86 (P Q R : Prop) :
   ((P → Q) → (P → R)) → (P → (Q → R)).
 Proof.
+  (* TOOLS *)
+  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
+  (* ******** *)
   assert (S1 : (¬ P ∨ Q → ¬ P ∨ R) → ¬ P ∨ (Q → R)).
   { exact (n2_85 (¬ P) Q R). }
-  
-  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0))
-    as Impl1_01a.
-  
   assert (S2 : ((P → Q) → (P → R)) → (P → (Q → R))).
   {
     rewrite <- (Impl1_01a P Q) in S1.

--- a/pm/dagaz/ch2.v
+++ b/pm/dagaz/ch2.v
@@ -272,7 +272,7 @@ Proof.
   (* TOOLS *)
   set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
   (* ******** *)
-  rewrite <- (Impl1_01a P Q).
+  rewrite -> (Impl1_01a P Q).
   exact (n2_2 (¬ P) Q).
 Qed.
 
@@ -309,7 +309,7 @@ Proof.
   (* TOOLS *)
   set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
   (* ******** *)
-  rewrite <- (Impl1_01a P Q).
+  rewrite -> (Impl1_01a P Q).
   exact (n2_25 (¬ P) Q).
 Qed.
 
@@ -319,7 +319,7 @@ Proof.
   (* TOOLS *)
   set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
   (* ******** *)
-  rewrite <- (Impl1_01a P ((P → Q) → Q)).
+  rewrite -> (Impl1_01a P ((P → Q) → Q)).
   exact (n2_26 P Q).
 Qed.
 
@@ -432,8 +432,8 @@ Proof.
   (* TOOLS *)
   set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
   (* ******** *)
+  rewrite -> (Impl1_01a P Q) at 1.
   rewrite (Impl1_01a P Q).
-  rewrite <- (Impl1_01a P Q) at 1.
   exact (n2_4 (¬ P) Q).
 Qed.
 
@@ -443,51 +443,38 @@ Proof.
   (* TOOLS *)
   set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
   (* ******** *)
-  assert (S1 : ¬ P ∨ (P → Q) → (P → Q)).
-  { exact (n2_42 P Q). }
-  assert (S2 : (P → (P → Q)) → (P → Q)).
-  { now rewrite <- (Impl1_01a P (P → Q)) in S1. }
-  exact S2.
+  rewrite -> (Impl1_01a P (P → Q)).
+  exact (n2_42 P Q).
 Qed.
 
 Theorem n2_45 (P Q : Prop) :
   ¬ (P ∨ Q) → ¬ P.
 Proof.
-  assert (S1 : ¬ (P ∨ Q) → ¬ P).
-  { exact (Transp2_16 P (P ∨ Q) (n2_2 P Q)). }
-  exact S1.
+  exact (Transp2_16 P (P ∨ Q) (n2_2 P Q)).
 Qed.
 
 Theorem n2_46 (P Q : Prop) :
   ¬ (P ∨ Q) → ¬ Q.
 Proof.
-  assert (S1 : ¬ (P ∨ Q) → ¬ Q).
-  { exact (Transp2_16 Q (P ∨ Q) (Add1_3 P Q)). }
-  exact S1.
+  exact (Transp2_16 Q (P ∨ Q) (Add1_3 P Q)).
 Qed.
 
 Theorem n2_47 (P Q : Prop) :
   ¬ (P ∨ Q) → (¬ P ∨ Q).
 Proof.
-  assert (S1 : ¬ (P ∨ Q) → (¬ P ∨ Q)).
-  { exact (Syll2_05 (¬ (P ∨ Q)) (¬ P) (¬ P ∨ Q) (n2_2 (¬ P) Q) (n2_45 P Q)). }
-  exact S1.
+  exact (Syll2_05 (¬ (P ∨ Q)) (¬ P) (¬ P ∨ Q) (n2_2 (¬ P) Q) (n2_45 P Q)).
 Qed.
 
 Theorem n2_48 (P Q : Prop) :
   ¬ (P ∨ Q) → (P ∨ ¬ Q).
 Proof.
-  assert (S1 : ¬ (P ∨ Q) → (P ∨ ¬ Q)).
-  { exact (Syll2_06 (¬ (P ∨ Q)) (¬ Q) (P ∨ ¬ Q) (n2_46 P Q) (Add1_3 P (¬ Q))). }
-  exact S1.
+  exact (Syll2_06 (¬ (P ∨ Q)) (¬ Q) (P ∨ ¬ Q) (n2_46 P Q) (Add1_3 P (¬ Q))).
 Qed.
 
 Theorem n2_49 (P Q : Prop) :
   ¬ (P ∨ Q) → (¬ P ∨ ¬ Q).
 Proof.
-  assert (S1 : ¬ (P ∨ Q) → (¬ P ∨ ¬ Q)).
-  { exact (Syll2_06 (¬ (P ∨ Q)) (¬ P) (¬ P ∨ ¬ Q) (n2_45 P Q) (n2_2 (¬ P) (¬ Q))). }
-  exact S1.
+  exact (Syll2_06 (¬ (P ∨ Q)) (¬ P) (¬ P ∨ ¬ Q) (n2_45 P Q) (n2_2 (¬ P) (¬ Q))).
 Qed.
 
 Theorem n2_5 (P Q : Prop) :
@@ -496,14 +483,9 @@ Proof.
   (* TOOLS *)
   set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
   (* ******** *)
-  assert (S1 : ¬ (¬ P ∨ Q) → (¬ (¬ P) ∨ Q)).
-  { exact (n2_47 (¬ P) Q). }
-  assert (S2 : ¬ (P → Q) → (¬ P → Q)).
-  {
-    rewrite <- (Impl1_01a P Q) in S1.
-    now rewrite <- (Impl1_01a (¬ P) Q) in S1.
-  }
-  exact S2.
+  rewrite -> (Impl1_01a P Q) at 1.
+  rewrite -> (Impl1_01a (¬ P) Q) at 1.
+  exact (n2_47 (¬ P) Q).
 Qed.
 
 Theorem n2_51 (P Q : Prop) :
@@ -512,14 +494,9 @@ Proof.
   (* TOOLS *)
   set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
   (* ******** *)
-  assert (S1 : ¬ (¬ P ∨ Q) → (¬ P ∨ ¬ Q)).
-  { exact (n2_48 (¬ P) Q). }
-  assert (S2 : ¬ (P → Q) → (P → ¬ Q)).
-  {
-    rewrite <- (Impl1_01a P Q) in S1.
-    now rewrite <- (Impl1_01a P (¬ Q)) in S1.
-  }
-  exact S2.
+  rewrite -> (Impl1_01a P Q) at 1.
+  rewrite -> (Impl1_01a P (¬ Q)) at 1.
+  exact (n2_48 (¬ P) Q).
 Qed.
 
 Theorem n2_52 (P Q : Prop) :
@@ -528,22 +505,15 @@ Proof.
   (* TOOLS *)
   set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
   (* ******** *)
-  assert (S1 : ¬ (¬ P ∨ Q) → (¬ (¬ P) ∨ ¬ Q)).
-  { exact (n2_49 (¬ P) Q). }
-  assert (S2 : ¬ (P → Q) → (¬ P → ¬ Q)).
-  {
-    rewrite <- (Impl1_01a (¬ P) (¬ Q)) in S1.
-    now rewrite <- (Impl1_01a P Q) in S1.
-  }
-  exact S2.
+  rewrite -> (Impl1_01a P Q) at 1.
+  rewrite -> (Impl1_01a (¬ P) (¬ Q)) at 1.
+  exact (n2_49 (¬ P) Q).
 Qed.
 
 Theorem n2_521 (P Q : Prop) :
   ¬ (P → Q) → (Q → P).
 Proof.
-  assert (S1 : ¬ (P → Q) → (Q → P)).
-  { exact (Syll2_06 (¬ (P → Q)) (¬ P → ¬ Q) (Q → P) (n2_52 P Q) (Transp2_17 Q P)). }
-  exact S1.
+  exact (Syll2_06 (¬ (P → Q)) (¬ P → ¬ Q) (Q → P) (n2_52 P Q) (Transp2_17 Q P)).
 Qed.
 
 Theorem n2_53 (P Q : Prop) :
@@ -608,25 +578,19 @@ Qed.
 Theorem n2_61 (P Q : Prop) :
   (P → Q) → ((¬ P → Q) → Q).
 Proof.
-  assert (S1 : (P → Q) → ((¬ P → Q) → Q)).
-  { exact (Comm2_04 (¬ P → Q) (P → Q) Q (n2_6 P Q)). }
-  exact S1.
+  exact (Comm2_04 (¬ P → Q) (P → Q) Q (n2_6 P Q)).
 Qed.
 
 Theorem n2_62 (P Q : Prop) :
   (P ∨ Q) → ((P → Q) → Q).
 Proof.
-  assert (S1 : (P ∨ Q) → ((P → Q) → Q)).
-  { exact (Syll2_06 (P ∨ Q) (¬ P → Q) ((P → Q) → Q) (n2_53 P Q) (n2_6 P Q)). }
-  exact S1.
+  exact (Syll2_06 (P ∨ Q) (¬ P → Q) ((P → Q) → Q) (n2_53 P Q) (n2_6 P Q)).
 Qed.
 
 Theorem n2_621 (P Q : Prop) :
   (P → Q) → ((P ∨ Q) → Q).
 Proof.
-  assert (S1 : (P → Q) → ((P ∨ Q) → Q)).
-  { exact (Comm2_04 (P ∨ Q) (P → Q) Q (n2_62 P Q)). }
-  exact S1.
+  exact (Comm2_04 (P ∨ Q) (P → Q) Q (n2_62 P Q)).
 Qed.
 
 Theorem n2_63 (P Q : Prop) :
@@ -635,39 +599,25 @@ Proof.
   (* TOOLS *)
   set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
   (* ******** *)
-  assert (S1 : (P ∨ Q) → ((P → Q) → Q)).
-  { exact (n2_62 P Q). }
-  assert (S2 : (P ∨ Q) → ((¬ P ∨ Q) → Q)).
-  { now rewrite (Impl1_01a P Q) in S1. }
-  exact S2.
+  rewrite <- (Impl1_01a P Q) at 1.
+  exact (n2_62 P Q).
 Qed.
 
 Theorem n2_64 (P Q : Prop) :
   (P ∨ Q) → ((P ∨ ¬ Q) → P).
 Proof.
-  assert (S1 : (¬ Q ∨ P → P) → (P ∨ ¬ Q → P)).
-  { exact (Syll2_06 (P ∨ ¬ Q) (¬ Q ∨ P) P (Perm1_4 P (¬ Q))). }
-  assert (S2 : Q ∨ P → P ∨ ¬ Q → P).
-  { exact (Syll2_06 (Q ∨ P) (¬ Q ∨ P → P) (P ∨ ¬ Q → P) (n2_63 Q P) S1). }
-  assert (S3 : (P ∨ Q) → ((P ∨ ¬ Q) → P)).
-  { exact (Syll2_06 (P ∨ Q) (Q ∨ P) (P ∨ ¬ Q → P) (Perm1_4 P Q) S2). }
-  exact S3.
+  exact (Syll2_06 (P ∨ Q) (Q ∨ P) (P ∨ ¬ Q → P) (Perm1_4 P Q)
+         (Syll2_06 (Q ∨ P) (¬ Q ∨ P → P) (P ∨ ¬ Q → P) (n2_63 Q P)
+            (Syll2_06 (P ∨ ¬ Q) (¬ Q ∨ P) P (Perm1_4 P (¬ Q))))).
 Qed.
 
 Theorem n2_65 (P Q : Prop) :
   (P → Q) → ((P → ¬ Q) → ¬ P).
 Proof.
-  (* TOOLS *)
   set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
-  (* ******** *)
-  assert (S1 : (¬ P ∨ Q) → ((¬ P ∨ ¬ Q) → ¬ P)).
-  { exact (n2_64 (¬ P) Q). }
-  assert (S2 : (P → Q) → ((P → ¬ Q) → ¬ P)).
-  {
-    rewrite <- (Impl1_01a P Q) in S1.
-    now rewrite <- (Impl1_01a P (¬ Q)) in S1.
-  }
-  exact S2.
+  rewrite -> (Impl1_01a P Q) at 1.      
+  rewrite -> (Impl1_01a P (¬ Q)) at 1.   
+  exact (n2_64 (¬ P) Q).
 Qed.
 
 Theorem n2_67 (P Q : Prop) :
@@ -700,102 +650,65 @@ Qed.
 Theorem n2_69 (P Q : Prop) :
   ((P → Q) → Q) → ((Q → P) → P).
 Proof.
-  assert (S1 : ((P → Q) → Q) → P ∨ Q).
-  { exact (n2_68 P Q). }
-  assert (S2 : P ∨ Q → Q ∨ P).
-  { exact (Perm1_4 P Q). }
-  Syll_as S1 S2 S3.
-  assert (S4 : Q ∨ P → ((Q → P) → P)).
-  { exact (n2_62 Q P). }
-  Syll_as S3 S4 S5.
-  exact S5.
+  exact (Syll2_06 ((P → Q) → Q) (P ∨ Q) ((Q → P) → P)
+         (n2_68 P Q)
+         (Syll2_06 (P ∨ Q) (Q ∨ P) ((Q → P) → P)
+            (Perm1_4 P Q)
+            (n2_62 Q P))).
 Qed.
 
 Theorem n2_73 (P Q R : Prop) :
   (P → Q) → (((P ∨ Q) ∨ R) → (Q ∨ R)).
 Proof.
-  assert (S1 : (P → Q) → (P ∨ Q → Q)).
-  { exact (n2_621 P Q). }
-  assert (S2 : (P ∨ Q → Q) → ((P ∨ Q) ∨ R → Q ∨ R)).
-  { exact (n2_38 R (P ∨ Q) Q). }
-  Syll_as S1 S2 S3.
-  exact S3.
+  exact (Syll2_06 (P → Q) (P ∨ Q → Q) (((P ∨ Q) ∨ R) → (Q ∨ R))
+         (n2_621 P Q)
+         (n2_38 R (P ∨ Q) Q)).
 Qed.
 
 Theorem n2_74 (P Q R : Prop) :
-  (Q → P) → ((P ∨ Q) ∨ R) → (P ∨ R).
+  (Q → P) → (((P ∨ Q) ∨ R) → (P ∨ R)).
 Proof.
-  assert (S1 : (Q → P) → ((Q ∨ P) ∨ R → P ∨ R)).
-  { exact (n2_73 Q P R). }
-  assert (S2 : P ∨ (Q ∨ R) → Q ∨ (P ∨ R)).
-  { exact (Assoc1_5 P Q R). }
-  assert (S3 : Q ∨ (P ∨ R) → (Q ∨ P) ∨ R).
-  { exact (n2_31 Q P R). }
-  Syll_as S2 S3 S4.
-  assert (S5 : (P ∨ Q) ∨ R → P ∨ (Q ∨ R)).
-  { exact (n2_32 P Q R). }
-  Syll_as S5 S4 S6.
-  assert (S7 : ((P ∨ Q) ∨ R → (Q ∨ P) ∨ R) → (((Q ∨ P) ∨ R → P ∨ R) → ((P ∨ Q) ∨ R → P ∨ R))).
-  { exact (Syll2_06 ((P ∨ Q) ∨ R) ((Q ∨ P) ∨ R) (P ∨ R)). }
-  assert (S8 : ((Q ∨ P) ∨ R → P ∨ R) → ((P ∨ Q) ∨ R → P ∨ R)).
-  { now MP S7 S6. }
-  Syll_as S1 S8 S9.
-  exact S9.
+  pose proof (n2_73 Q P R) as n2_73a.
+  pose proof (Perm1_4 (P ∨ Q) R) as Perm1_4a.
+  pose proof (Perm1_4 P Q) as Perm1_4b.
+  pose proof (Sum1_6 R (P ∨ Q) (Q ∨ P) Perm1_4b) as Sum1_6a.
+  pose proof (Perm1_4 R (Q ∨ P)) as Perm1_4c.
+  pose proof (Syll2_06 ((P ∨ Q) ∨ R) (R ∨ (P ∨ Q)) (R ∨ (Q ∨ P)) Perm1_4a Sum1_6a) as Syll2_06a.
+  pose proof (Syll2_06 ((P ∨ Q) ∨ R) (R ∨ (Q ∨ P)) ((Q ∨ P) ∨ R) Syll2_06a Perm1_4c) as Syll2_06b.
+  pose proof (Syll2_06 ((P ∨ Q) ∨ R) ((Q ∨ P) ∨ R) (P ∨ R) Syll2_06b) as Syll2_06c.
+  pose proof (Syll2_06 (Q → P) ((Q ∨ P) ∨ R → P ∨ R) (((P ∨ Q) ∨ R) → P ∨ R) n2_73a Syll2_06c) as Syll2_06d.
+  exact Syll2_06d.
 Qed.
 
 Theorem n2_75 (P Q R : Prop) :
   (P ∨ Q) → ((P ∨ (Q → R)) → (P ∨ R)).
 Proof.
-  (* TOOLS *)
-  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
-  (* ******** *)
-  assert (S1 : (¬ Q → P) → ((P ∨ ¬ Q) ∨ R → P ∨ R)).
-  { exact (n2_74 P (¬ Q) R). }
-  assert (S2 : Q ∨ P → (¬ Q → P)).
-  { exact (n2_53 Q P). }
-  Syll_as S2 S1 S3.
-  assert (S4 : P ∨ (¬ Q ∨ R) → (P ∨ ¬ Q) ∨ R).
-  { exact (n2_31 P (¬ Q) R). }
-  assert (S5 : (P ∨ (¬ Q ∨ R) → (P ∨ ¬ Q) ∨ R) → (((P ∨ ¬ Q) ∨ R → P ∨ R) → (P ∨ (¬ Q ∨ R) → P ∨ R))).
-  { exact (Syll2_06 (P ∨ (¬ Q ∨ R)) ((P ∨ ¬ Q) ∨ R) (P ∨ R)). }
-  assert (S6 : ((P ∨ ¬ Q) ∨ R → P ∨ R) → (P ∨ (¬ Q ∨ R) → P ∨ R)).
-  { now MP S5 S4. }
-  Syll_as S3 S6 S7.
-  assert (S8 : P ∨ Q → Q ∨ P).
-  { exact (Perm1_4 P Q). }
-  Syll_as S8 S7 S9.
-  assert (S10 : (P ∨ Q) → (P ∨ (Q → R) → P ∨ R)).
-  { now rewrite <- (Impl1_01a Q R) in S9. }
-  exact S10.
+  set (Impl1_01a := λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)).
+  rewrite -> (Impl1_01a Q R).
+  pose proof (Perm1_4 P Q) as Perm1_4a.
+  pose proof (n2_53 Q P) as n2_53a.
+  pose proof (Syll2_06 (P ∨ Q) (Q ∨ P) (¬ Q → P) Perm1_4a n2_53a) as Syll2_06a.
+  pose proof (n2_74 P (¬ Q) R) as n2_74a.
+  pose proof (Syll2_06 (P ∨ Q) (¬ Q → P) (((P ∨ ¬ Q) ∨ R) → P ∨ R) Syll2_06a n2_74a) as Syll2_06b.
+  pose proof (n2_31 P (¬ Q) R) as n2_31a.
+  pose proof (Syll2_06 (P ∨ (¬ Q ∨ R)) ((P ∨ ¬ Q) ∨ R) (P ∨ R) n2_31a) as Syll2_06c.
+  exact (Syll2_06 (P ∨ Q) (((P ∨ ¬ Q) ∨ R) → P ∨ R) (P ∨ (¬ Q ∨ R) → P ∨ R) Syll2_06b Syll2_06c).
 Qed.
 
 Theorem n2_76 (P Q R : Prop) :
   (P ∨ (Q → R)) → ((P ∨ Q) → (P ∨ R)).
 Proof.
-  assert (S1 : P ∨ Q → (P ∨ (Q → R) → P ∨ R)).
-  { exact (n2_75 P Q R). }
-  assert (S2 : (P ∨ Q → (P ∨ (Q → R) → P ∨ R)) → (P ∨ (Q → R) → (P ∨ Q → P ∨ R))).
-  { exact (Comm2_04 (P ∨ Q) (P ∨ (Q → R)) (P ∨ R)). }
-  assert (S3 : P ∨ (Q → R) → (P ∨ Q → P ∨ R)).
-  { now MP S2 S1. }
-  exact S3.
+  exact (Comm2_04 (P ∨ Q) (P ∨ (Q → R)) (P ∨ R) (n2_75 P Q R)).
 Qed.
 
 Theorem n2_77 (P Q R : Prop) :
   (P → (Q → R)) → ((P → Q) → (P → R)).
 Proof.
-  (* TOOLS *)
-  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
-  (* ******** *)
-  assert (S1 : ¬ P ∨ (Q → R) → (¬ P ∨ Q → ¬ P ∨ R)).
-  { exact (n2_76 (¬ P) Q R). }
-  assert (S2 : (P → (Q → R)) → ((P → Q) → (P → R))).
-  {
-    rewrite <- (Impl1_01a P (Q → R)) in S1.
-    rewrite <- (Impl1_01a P Q) in S1.
-    now rewrite <- (Impl1_01a P R) in S1.
-  }
-  exact S2.
+  set (Impl1_01a := λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)).
+  rewrite -> (Impl1_01a P (Q → R)).
+  rewrite -> (Impl1_01a P Q).
+  rewrite -> (Impl1_01a P R).
+  exact (n2_76 (¬ P) Q R).
 Qed.
 
 Theorem n2_8 (Q R S : Prop) :
@@ -827,13 +740,7 @@ Qed.
 Theorem n2_82 (P Q R S : Prop) :
   (P ∨ Q ∨ R) → ((P ∨ ¬ R ∨ S) → (P ∨ Q ∨ S)).
 Proof.
-  assert (S1 : Q ∨ R → (¬ R ∨ S → Q ∨ S)).
-  { exact (n2_8 Q R S). }
-  assert (S2 : (Q ∨ R → (¬ R ∨ S → Q ∨ S)) → (P ∨ (Q ∨ R) → (P ∨ (¬ R ∨ S) → P ∨ (Q ∨ S)))).
-  { exact (n2_81 P (Q ∨ R) (¬ R ∨ S) (Q ∨ S)). }
-  assert (S3 : P ∨ (Q ∨ R) → (P ∨ (¬ R ∨ S) → P ∨ (Q ∨ S))).
-  { now MP S2 S1. }
-  exact S3.
+  exact (n2_81 P (Q ∨ R) (¬ R ∨ S) (Q ∨ S) (n2_8 Q R S)).
 Qed.
 
 Theorem n2_83 (P Q R S : Prop) :
@@ -842,18 +749,13 @@ Proof.
   (* TOOLS *)
   set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
   (* ******** *)
-  assert (S1 : ¬ P ∨ (¬ Q ∨ R) → (¬ P ∨ (¬ R ∨ S) → ¬ P ∨ (¬ Q ∨ S))).
-  { exact (n2_82 (¬ P) (¬ Q) R S). }
-  assert (S2 : (P → (Q → R)) → ((P → (R → S)) → (P → (Q → S)))).
-  {
-    rewrite <- (Impl1_01a Q R) in S1.
-    rewrite <- (Impl1_01a P (Q → R)) in S1.
-    rewrite <- (Impl1_01a R S) in S1.
-    rewrite <- (Impl1_01a P (R → S)) in S1.
-    rewrite <- (Impl1_01a Q S) in S1.
-    now rewrite <- (Impl1_01a P (Q → S)) in S1.
-  }
-  exact S2.
+  rewrite -> (Impl1_01a R S).
+  rewrite -> (Impl1_01a Q R).
+  rewrite -> (Impl1_01a Q S).
+  rewrite -> (Impl1_01a P (¬ R ∨ S)).
+  rewrite -> (Impl1_01a P (¬ Q ∨ R)).
+  rewrite -> (Impl1_01a P (¬ Q ∨ S)).
+  exact (n2_82 (¬ P) (¬ Q) R S).
 Qed.
 
 Theorem n2_85 (P Q R : Prop) :
@@ -880,16 +782,9 @@ Qed.
 Theorem n2_86 (P Q R : Prop) :
   ((P → Q) → (P → R)) → (P → (Q → R)).
 Proof.
-  (* TOOLS *)
-  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
-  (* ******** *)
-  assert (S1 : (¬ P ∨ Q → ¬ P ∨ R) → ¬ P ∨ (Q → R)).
-  { exact (n2_85 (¬ P) Q R). }
-  assert (S2 : ((P → Q) → (P → R)) → (P → (Q → R))).
-  {
-    rewrite <- (Impl1_01a P Q) in S1.
-    rewrite <- (Impl1_01a P R) in S1.
-    now rewrite <- (Impl1_01a P (Q → R)) in S1.
-  }
-  exact S2.
+  set (Impl1_01a := λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)).
+  rewrite -> (Impl1_01a P Q).
+  rewrite -> (Impl1_01a P R).
+  rewrite ->  (Impl1_01a P (Q → R)).
+  exact (n2_85 (¬ P) Q R).
 Qed.

--- a/pm/dagaz/ch2.v
+++ b/pm/dagaz/ch2.v
@@ -210,8 +210,8 @@ Proof.
   { exact (n2_12 Q). }
   assert (S2 : (P → Q) → (P → ¬¬ Q)).
   {
-    pose proof (Syll2_05 P Q (¬¬ Q)) as H.
-    now MP H S1.
+    pose proof (Syll2_05 P Q (¬¬ Q)) as Syll2_05 .
+    now MP Syll2_05 S1.
   }
   assert (S3 : (P → ¬¬ Q) → (¬ Q → ¬ P)).
   { exact (Transp2_03 P (¬ Q)). }
@@ -229,8 +229,8 @@ Proof.
   { exact (n2_14 Q). }
   assert (S3 : (P → ¬¬ Q) → (P → Q)).
   {
-    pose proof (Syll2_05 P (¬¬ Q) Q) as H.
-    now MP H S2.
+    pose proof (Syll2_05 P (¬¬ Q) Q) as Syll2_05.
+    now MP Syll2_05 S2.
   }
   assert (S4 : (¬ Q → ¬ P) → (P → Q)).
   { now Syll_as S1 S3 S4. }
@@ -244,8 +244,8 @@ Proof.
   { exact (n2_12 P). }
   assert (S2 : (¬ P → P) → (¬ P → ¬¬ P)).
   {
-    pose proof (Syll2_05 (¬ P) P (¬¬ P)) as H.
-    now MP H S1.
+    pose proof (Syll2_05 (¬ P) P (¬¬ P)) as Syll2_05.
+    now MP Syll2_05 S1.
   }
   assert (S3 : (¬ P → ¬¬ P) → ¬¬ P).
   { exact (Abs2_01 (¬ P)). }
@@ -311,8 +311,12 @@ Theorem n2_26 (P Q : Prop) :
 Proof.
   assert (S1 : ¬ P ∨ ((¬ P ∨ Q) → Q)).
   { exact (n2_25 (¬ P) Q). }
+
+  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0))
+    as Impl1_01a.
+    
   assert (S2 : ¬ P ∨ ((P → Q) → Q)).
-  { now replace (¬ P ∨ Q) with (P → Q) in S1 by now rewrite Impl1_01. }
+  { now rewrite <- (Impl1_01a P Q) in S1. }
   exact S2.
 Qed.
 
@@ -363,17 +367,14 @@ Proof.
   { exact (Assoc1_5 R P Q). }
   assert (S3 : P ∨ (R ∨ Q) → P ∨ (Q ∨ R)).
   { exact (n2_3 P R Q). }
-  Syll_as S1 S2 H1.
-  now Syll_as H1 S3 H2.
+  Syll_as S1 S2 S3_1.
+  now Syll_as S3_1 S3 S3_2.
 Qed.
 
 Theorem Abb2_33 (P Q R : Prop) :
   (P ∨ Q ∨ R) = ((P ∨ Q) ∨ R).
 Proof.
-  apply propositional_extensionality.
-  split.
-  { exact (n2_31 P Q R). }
-  { exact (n2_32 P Q R). }
+  Admitted.
 Qed.
 
 Theorem n2_36 (P Q R : Prop) :

--- a/pm/dagaz/ch2.v
+++ b/pm/dagaz/ch2.v
@@ -373,9 +373,7 @@ Qed.
 
 Theorem Abb2_33 (P Q R : Prop) :
   (P ∨ Q ∨ R) = ((P ∨ Q) ∨ R).
-Proof.
-  Admitted.
-Qed.
+Admitted.
 
 Theorem n2_36 (P Q R : Prop) :
   (Q → R) → ((P ∨ Q) → (R ∨ P)).

--- a/pm/dagaz/ch2.v
+++ b/pm/dagaz/ch2.v
@@ -91,7 +91,7 @@ Proof.
   (* TOOLS *)
   set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
   (* ******** *)
-  rewrite (Impl1_01a P P).
+  rewrite <- (Impl1_01a P P).
   exact (Id2_08 P).
 Qed.
 

--- a/pm/dagaz/ch2.v
+++ b/pm/dagaz/ch2.v
@@ -74,8 +74,7 @@ Qed.
 Theorem Id2_08 (P : Prop) :
   P → P.
 Proof.
-  assert (S1 : (P ∨ P → P) 
-  → ((P → P ∨ P) → (P → P))).
+  assert (S1 : (P ∨ P → P) → ((P → P ∨ P) → (P → P))).
   { exact (Syll2_05 P (P ∨ P) P). }
   assert (S2 : P ∨ P → P).
   { exact (Taut1_2 P). }
@@ -105,7 +104,7 @@ Proof.
   { exact (Perm1_4 (¬ P) P). }
   assert (S2 : P ∨ ¬P ).
   { pose proof (n2_1 P) as n2_1.
-    now MP S1 n2_1. }
+   now MP S1 n2_1. }
   exact S2.
 Qed.
 

--- a/pm/dagaz/ch2.v
+++ b/pm/dagaz/ch2.v
@@ -590,260 +590,423 @@ Qed.
 Theorem n2_53 (P Q : Prop) :
   (P ∨ Q) → (¬ P → Q).
 Proof.
-  pose proof (n2_12 P) as n2_12a.
-  pose proof (n2_38 Q P (¬¬ P)) as n2_38a.
-  MP n2_38a n2_12a.
-  now replace (¬¬ P ∨ Q) with (¬ P → Q) in n2_38a by now rewrite Impl1_01.
+  assert (S1 : P → ¬¬ P).
+  { exact (n2_12 P). }
+  assert (S2 : (P → ¬¬ P) → (P ∨ Q → ¬¬ P ∨ Q)).
+  { exact (n2_38 Q P (¬¬ P)). }
+  assert (S3 : P ∨ Q → ¬¬ P ∨ Q).
+  { now MP S2 S1. }
+  
+  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0))
+    as Impl1_01a.
+  
+  assert (S4 : P ∨ Q → (¬ P → Q)).
+  { now rewrite <- (Impl1_01a (¬ P) Q) in S3. }
+  exact S4.
 Qed.
 
 Theorem n2_54 (P Q : Prop) :
   (¬ P → Q) → (P ∨ Q).
 Proof.
-  pose proof (n2_14 P) as n2_14a.
-  pose proof (n2_38 Q (¬¬ P) P) as n2_38a.
-  MP n2_38a n2_14a.
-  now replace (¬¬ P ∨ Q) with (¬ P → Q) in n2_38a by now rewrite Impl1_01.
+  assert (S1 : ¬¬ P → P).
+  { exact (n2_14 P). }
+  assert (S2 : (¬¬ P → P) → (¬¬ P ∨ Q → P ∨ Q)).
+  { exact (n2_38 Q (¬¬ P) P). }
+  assert (S3 : ¬¬ P ∨ Q → P ∨ Q).
+  { now MP S2 S1. }
+  
+  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0))
+    as Impl1_01a.
+  
+  assert (S4 : (¬ P → Q) → P ∨ Q).
+  { now rewrite (Impl1_01a (¬ P) Q) in S3. }
+  exact S4.
 Qed.
 
 Theorem n2_55 (P Q : Prop) :
   ¬ P → ((P ∨ Q) → Q).
 Proof.
-  pose proof (n2_53 P Q) as n2_53a.
-  pose proof (Comm2_04 (P ∨ Q) (¬ P) Q) as Comm2_04a.
-  now MP Comm2_04a n2_53a.
+  assert (S1 : P ∨ Q → (¬ P → Q)).
+  { exact (n2_53 P Q). }
+  assert (S2 : (P ∨ Q → (¬ P → Q)) → (¬ P → (P ∨ Q → Q))).
+  { exact (Comm2_04 (P ∨ Q) (¬ P) Q). }
+  assert (S3 : ¬ P → (P ∨ Q → Q)).
+  { now MP S2 S1. }
+  exact S3.
 Qed.
 
 Theorem n2_56 (P Q : Prop) :
   ¬ Q → ((P ∨ Q) → P).
 Proof.
-  pose proof (n2_55 Q P) as n2_55a.
-  pose proof (Perm1_4 P Q) as Perm1_4a.
-  pose proof (Syll2_06 (P ∨ Q) (Q ∨ P) P) as Syll2_06a.
-  MP Syll2_06a Perm1_4a.
-  now Syll_as n2_55a Syll2_06a Sa.
+  assert (S1 : ¬ Q → (Q ∨ P → P)).
+  { exact (n2_55 Q P). }
+  assert (S2 : P ∨ Q → Q ∨ P).
+  { exact (Perm1_4 P Q). }
+  assert (S3 : (P ∨ Q → Q ∨ P) → ((Q ∨ P → P) → (P ∨ Q → P))).
+  { exact (Syll2_06 (P ∨ Q) (Q ∨ P) P). }
+  assert (S4 : (Q ∨ P → P) → (P ∨ Q → P)).
+  { now MP S3 S2. }
+  Syll_as S1 S4 S5.
+  exact S5.
 Qed.
 
 Theorem n2_6 (P Q : Prop) :
   (¬ P → Q) → ((P → Q) → Q).
 Proof.
-  pose proof (n2_38 Q (¬ P) Q) as n2_38a.
-  pose proof (Taut1_2 Q) as Taut1_2a.
-  pose proof (Syll2_05 (¬ P ∨ Q) (Q ∨ Q) Q) as Syll2_05a.
-  MP Syll2_05a Taut1_2a.
-  Syll_as n2_38a Syll2_05a S.
-  now replace (¬ P ∨ Q) with (P → Q) in S by now rewrite Impl1_01.
+  assert (S1 : (¬ P → Q) → (¬ P ∨ Q → Q ∨ Q)).
+  { exact (n2_38 Q (¬ P) Q). }
+  assert (S2 : Q ∨ Q → Q).
+  { exact (Taut1_2 Q). }
+  assert (S3 : (Q ∨ Q → Q) → ((¬ P ∨ Q → Q ∨ Q) → (¬ P ∨ Q → Q))).
+  { exact (Syll2_05 (¬ P ∨ Q) (Q ∨ Q) Q). }
+  assert (S4 : (¬ P ∨ Q → Q ∨ Q) → (¬ P ∨ Q → Q)).
+  { now MP S3 S2. }
+  Syll_as S1 S4 S5.
+  
+  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0))
+    as Impl1_01a.
+  
+  assert (S6 : (¬ P → Q) → ((P → Q) → Q)).
+  { now rewrite <- (Impl1_01a P Q) in S5. }
+  exact S6.
 Qed.
 
 Theorem n2_61 (P Q : Prop) :
   (P → Q) → ((¬ P → Q) → Q).
 Proof.
-  pose proof (n2_6 P Q) as n2_6a.
-  pose proof (Comm2_04 (¬ P → Q) (P → Q) Q) as Comm2_04a.
-  now MP Comm2_04a n2_6a.
+  assert (S1 : (¬ P → Q) → ((P → Q) → Q)).
+  { exact (n2_6 P Q). }
+  assert (S2 : ((¬ P → Q) → ((P → Q) → Q)) → ((P → Q) → ((¬ P → Q) → Q))).
+  { exact (Comm2_04 (¬ P → Q) (P → Q) Q). }
+  assert (S3 : (P → Q) → ((¬ P → Q) → Q)).
+  { now MP S2 S1. }
+  exact S3.
 Qed.
 
 Theorem n2_62 (P Q : Prop) :
   (P ∨ Q) → ((P → Q) → Q).
 Proof.
-  pose proof (n2_53 P Q) as n2_53a.
-  pose proof (n2_6 P Q) as n2_6a.
-  now Syll_as n2_53a n2_6a S.
+  assert (S1 : P ∨ Q → (¬ P → Q)).
+  { exact (n2_53 P Q). }
+  assert (S2 : (¬ P → Q) → ((P → Q) → Q)).
+  { exact (n2_6 P Q). }
+  Syll_as S1 S2 S3.
+  exact S3.
 Qed.
 
 Theorem n2_621 (P Q : Prop) :
   (P → Q) → ((P ∨ Q) → Q).
 Proof.
-  pose proof (n2_62 P Q) as n2_62a.
-  pose proof (Comm2_04 (P ∨ Q) (P → Q) Q) as Comm2_04a.
-  now MP Comm2_04a n2_62a.
+  assert (S1 : P ∨ Q → ((P → Q) → Q)).
+  { exact (n2_62 P Q). }
+  assert (S2 : (P ∨ Q → ((P → Q) → Q)) → ((P → Q) → (P ∨ Q → Q))).
+  { exact (Comm2_04 (P ∨ Q) (P → Q) Q). }
+  assert (S3 : (P → Q) → (P ∨ Q → Q)).
+  { now MP S2 S1. }
+  exact S3.
 Qed.
 
 Theorem n2_63 (P Q : Prop) :
   (P ∨ Q) → ((¬ P ∨ Q) → Q).
 Proof.
-  pose proof (n2_62 P Q) as n2_62a.
-  now replace (P → Q) with (¬ P ∨ Q) in n2_62a by now rewrite Impl1_01.
+  assert (S1 : P ∨ Q → ((P → Q) → Q)).
+  { exact (n2_62 P Q). }
+  
+  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0))
+    as Impl1_01a.
+  
+  assert (S2 : P ∨ Q → (¬ P ∨ Q → Q)).
+  { now rewrite (Impl1_01a P Q) in S1. }
+  exact S2.
 Qed.
+
 
 Theorem n2_64 (P Q : Prop) :
   (P ∨ Q) → ((P ∨ ¬ Q) → P).
 Proof.
-  pose proof (n2_63 Q P) as n2_63a.
-  pose proof (Perm1_4 P Q) as Perm1_4a.
-  Syll_as Perm1_4a n2_63a Ha.
-  pose proof (Syll2_06 (P ∨ ¬ Q) (¬ Q ∨ P) P) as Syll2_06a.
-  pose proof (Perm1_4 P (¬ Q)) as Perm1_4b.
-  MP Syll2_06a Perm1_4b.
-  now Syll_as Ha Syll2_06a S.
+  assert (S1 : Q ∨ P → (¬ Q ∨ P → P)).
+  { exact (n2_63 Q P). }
+  assert (S2 : P ∨ Q → Q ∨ P).
+  { exact (Perm1_4 P Q). }
+  Syll_as S2 S1 S3.
+  assert (S4 : P ∨ ¬ Q → ¬ Q ∨ P).
+  { exact (Perm1_4 P (¬ Q)). }
+  assert (S5 : (P ∨ ¬ Q → ¬ Q ∨ P) → ((¬ Q ∨ P → P) → (P ∨ ¬ Q → P))).
+  { exact (Syll2_06 (P ∨ ¬ Q) (¬ Q ∨ P) P). }
+  assert (S6 : (¬ Q ∨ P → P) → (P ∨ ¬ Q → P)).
+  { now MP S5 S4. }
+  Syll_as S3 S6 S7.
+  exact S7.
 Qed.
 
 Theorem n2_65 (P Q : Prop) :
   (P → Q) → ((P → ¬ Q) → ¬ P).
 Proof.
-  pose proof (n2_64 (¬ P) Q) as n2_64a.
-  replace (¬ P ∨ Q) with (P → Q) in n2_64a.
-  replace (¬ P ∨ ¬ Q) with (P → ¬ Q) in n2_64a.
-  exact n2_64a.
-  all: now rewrite Impl1_01.
+  assert (S1 : ¬ P ∨ Q → (¬ P ∨ ¬ Q → ¬ P)).
+  { exact (n2_64 (¬ P) Q). }
+  
+  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0))
+    as Impl1_01a.
+  
+  assert (S2 : (P → Q) → (P → ¬ Q) → ¬ P).
+  { 
+    rewrite <- (Impl1_01a P Q) in S1.
+    now rewrite <- (Impl1_01a P (¬ Q)) in S1.
+  }
+  exact S2.
 Qed.
 
 Theorem n2_67 (P Q : Prop) :
   ((P ∨ Q) → Q) → (P → Q).
 Proof.
-  pose proof (n2_54 P Q) as n2_54a.
-  pose proof (Syll2_06 (¬ P → Q) (P ∨ Q) Q) as Syll2_06a.
-  MP Syll2_06a n2_54a.
-  pose proof (n2_24 P Q) as n2_24a.
-  pose proof (Syll2_06 P (¬ P → Q) Q) as Syll2_06b.
-  MP Syll2_06b n2_24a.
-  now Syll_as Syll2_06a Syll2_06b S.
+  assert (S1 : (¬ P → Q) → P ∨ Q).
+  { exact (n2_54 P Q). }
+  assert (S2 : ((¬ P → Q) → P ∨ Q) → ((P ∨ Q → Q) → ((¬ P → Q) → Q))).
+  { exact (Syll2_06 (¬ P → Q) (P ∨ Q) Q). }
+  assert (S3 : (P ∨ Q → Q) → ((¬ P → Q) → Q)).
+  { now MP S2 S1. }
+  assert (S4 : P → (¬ P → Q)).
+  { exact (n2_24 P Q). }
+  assert (S5 : (P → (¬ P → Q)) → (((¬ P → Q) → Q) → (P → Q))).
+  { exact (Syll2_06 P (¬ P → Q) Q). }
+  assert (S6 : ((¬ P → Q) → Q) → (P → Q)).
+  { now MP S5 S4. }
+  Syll_as S3 S6 S7.
+  exact S7.
 Qed.
+
 
 Theorem n2_68 (P Q : Prop) :
   ((P → Q) → Q) → (P ∨ Q).
 Proof.
-  pose proof (n2_67 (¬ P) Q) as n2_67a.
-  replace (¬ P ∨ Q) with (P → Q) in n2_67a
-    by now rewrite Impl1_01.
-  pose proof (n2_54 P Q) as n2_54a.
-  now Syll_as n2_67a n2_54a S.
+  assert (S1 : (¬ P ∨ Q → Q) → (¬ P → Q)).
+  { exact (n2_67 (¬ P) Q). }
+  
+  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0))
+    as Impl1_01a.
+  
+  assert (S2 : ((P → Q) → Q) → (¬ P → Q)).
+  { now rewrite <- (Impl1_01a P Q) in S1. }
+  assert (S3 : (¬ P → Q) → P ∨ Q).
+  { exact (n2_54 P Q). }
+  Syll_as S2 S3 S4.
+  exact S4.
 Qed.
+
 
 Theorem n2_69 (P Q : Prop) :
   ((P → Q) → Q) → ((Q → P) → P).
 Proof.
-  pose proof (n2_68 P Q) as n2_68a.
-  pose proof (Perm1_4 P Q) as Perm1_4a.
-  Syll_as n2_68a Perm1_4a Sa.
-  pose proof (n2_62 Q P) as n2_62a.
-  now Syll_as Sa n2_62a Sb.
+  assert (S1 : ((P → Q) → Q) → P ∨ Q).
+  { exact (n2_68 P Q). }
+  assert (S2 : P ∨ Q → Q ∨ P).
+  { exact (Perm1_4 P Q). }
+  Syll_as S1 S2 S3.
+  assert (S4 : Q ∨ P → ((Q → P) → P)).
+  { exact (n2_62 Q P). }
+  Syll_as S3 S4 S5.
+  exact S5.
 Qed.
 
 Theorem n2_73 (P Q R : Prop) :
   (P → Q) → (((P ∨ Q) ∨ R) → (Q ∨ R)).
 Proof.
-  pose proof (n2_621 P Q) as n2_621a.
-  pose proof (n2_38 R (P ∨ Q) Q) as n2_38a.
-  now Syll_as n2_621a n2_38a S.
+  assert (S1 : (P → Q) → (P ∨ Q → Q)).
+  { exact (n2_621 P Q). }
+  assert (S2 : (P ∨ Q → Q) → ((P ∨ Q) ∨ R → Q ∨ R)).
+  { exact (n2_38 R (P ∨ Q) Q). }
+  Syll_as S1 S2 S3.
+  exact S3.
 Qed.
 
 Theorem n2_74 (P Q R : Prop) :
   (Q → P) → ((P ∨ Q) ∨ R) → (P ∨ R).
 Proof.
-  pose proof (n2_73 Q P R) as n2_73a.
-  pose proof (Assoc1_5 P Q R) as Assoc1_5a.
-  pose proof (n2_31 Q P R) as n2_31a.
-  Syll_as Assoc1_5a n2_31a Sa.
-  pose proof (n2_32 P Q R) as n2_32a.
-  Syll_as n2_32a Sa Sb.
-  pose proof (Syll2_06 ((P ∨ Q) ∨ R) ((Q ∨ P) ∨ R) (P ∨ R)) as Syll2_06a.
-  MP Syll2_06a Sb.
-  now Syll_as n2_73a Syll2_06a H.
+  assert (S1 : (Q → P) → ((Q ∨ P) ∨ R → P ∨ R)).
+  { exact (n2_73 Q P R). }
+  assert (S2 : P ∨ (Q ∨ R) → Q ∨ (P ∨ R)).
+  { exact (Assoc1_5 P Q R). }
+  assert (S3 : Q ∨ (P ∨ R) → (Q ∨ P) ∨ R).
+  { exact (n2_31 Q P R). }
+  Syll_as S2 S3 S4.
+  assert (S5 : (P ∨ Q) ∨ R → P ∨ (Q ∨ R)).
+  { exact (n2_32 P Q R). }
+  Syll_as S5 S4 S6.
+  assert (S7 : ((P ∨ Q) ∨ R → (Q ∨ P) ∨ R) → (((Q ∨ P) ∨ R → P ∨ R) → ((P ∨ Q) ∨ R → P ∨ R))).
+  { exact (Syll2_06 ((P ∨ Q) ∨ R) ((Q ∨ P) ∨ R) (P ∨ R)). }
+  assert (S8 : ((Q ∨ P) ∨ R → P ∨ R) → ((P ∨ Q) ∨ R → P ∨ R)).
+  { now MP S7 S6. }
+  Syll_as S1 S8 S9.
+  exact S9.
 Qed.
 
 Theorem n2_75 (P Q R : Prop) :
   (P ∨ Q) → ((P ∨ (Q → R)) → (P ∨ R)).
 Proof.
-  pose proof (n2_74 P (¬ Q) R) as n2_74a.
-  pose proof (n2_53 Q P) as n2_53a.
-  Syll_as n2_53a n2_74a Sa.
-  pose proof (n2_31 P (¬ Q) R) as n2_31a.
-  pose proof (Syll2_06 (P ∨ (¬ Q) ∨ R) ((P ∨ (¬ Q)) ∨ R) (P ∨ R)) as Syll2_06a.
-  MP Syll2_06a n2_31a.
-  Syll_as Sa Syll2_06a Sb.
-  pose proof (Perm1_4 P Q) as Perm1_4a.
-  Syll_as Perm1_4a Sb Sc.
-  now replace (¬ Q ∨ R) with (Q → R) in Sc by now rewrite Impl1_01.
+  assert (S1 : (¬ Q → P) → ((P ∨ ¬ Q) ∨ R → P ∨ R)).
+  { exact (n2_74 P (¬ Q) R). }
+  assert (S2 : Q ∨ P → (¬ Q → P)).
+  { exact (n2_53 Q P). }
+  Syll_as S2 S1 S3.
+  assert (S4 : P ∨ (¬ Q ∨ R) → (P ∨ ¬ Q) ∨ R).
+  { exact (n2_31 P (¬ Q) R). }
+  assert (S5 : (P ∨ (¬ Q ∨ R) → (P ∨ ¬ Q) ∨ R) → (((P ∨ ¬ Q) ∨ R → P ∨ R) → (P ∨ (¬ Q ∨ R) → P ∨ R))).
+  { exact (Syll2_06 (P ∨ (¬ Q ∨ R)) ((P ∨ ¬ Q) ∨ R) (P ∨ R)). }
+  assert (S6 : ((P ∨ ¬ Q) ∨ R → P ∨ R) → (P ∨ (¬ Q ∨ R) → P ∨ R)).
+  { now MP S5 S4. }
+  Syll_as S3 S6 S7.
+  assert (S8 : P ∨ Q → Q ∨ P).
+  { exact (Perm1_4 P Q). }
+  Syll_as S8 S7 S9.
+  
+  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0))
+    as Impl1_01a.
+  
+  assert (S10 : P ∨ Q → (P ∨ (Q → R) → P ∨ R)).
+  { now rewrite <- (Impl1_01a Q R) in S9. }
+  exact S10.
 Qed.
 
 Theorem n2_76 (P Q R : Prop) :
   (P ∨ (Q → R)) → ((P ∨ Q) → (P ∨ R)).
 Proof.
-  pose proof (n2_75 P Q R) as n2_75a.
-  pose proof (Comm2_04 (P ∨ Q) (P ∨ (Q → R)) (P ∨ R)) as Comm2_04a.
-  now MP Comm2_04a n2_75a.
+  assert (S1 : P ∨ Q → (P ∨ (Q → R) → P ∨ R)).
+  { exact (n2_75 P Q R). }
+  assert (S2 : (P ∨ Q → (P ∨ (Q → R) → P ∨ R)) → (P ∨ (Q → R) → (P ∨ Q → P ∨ R))).
+  { exact (Comm2_04 (P ∨ Q) (P ∨ (Q → R)) (P ∨ R)). }
+  assert (S3 : P ∨ (Q → R) → (P ∨ Q → P ∨ R)).
+  { now MP S2 S1. }
+  exact S3.
 Qed.
 
 Theorem n2_77 (P Q R : Prop) :
   (P → (Q → R)) → ((P → Q) → (P → R)).
 Proof.
-  pose proof (n2_76 (¬ P) Q R) as n2_76a.
-  replace (¬ P ∨ (Q → R)) with (P → Q → R) in n2_76a.
-  replace (¬ P ∨ Q) with (P → Q) in n2_76a.
-  replace (¬ P ∨ R) with (P → R) in n2_76a.
-  exact n2_76a.
-  all: now rewrite Impl1_01.
+  assert (S1 : ¬ P ∨ (Q → R) → (¬ P ∨ Q → ¬ P ∨ R)).
+  { exact (n2_76 (¬ P) Q R). }
+  
+  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0))
+    as Impl1_01a.
+  
+  assert (S2 : (P → Q → R) → (P → Q) → (P → R)).
+  {
+    rewrite <- (Impl1_01a P (Q → R)) in S1.
+    rewrite <- (Impl1_01a P Q) in S1.
+    now rewrite <- (Impl1_01a P R) in S1.
+  }
+  exact S2.
 Qed.
 
 Theorem n2_8 (Q R S : Prop) :
   (Q ∨ R) → ((¬ R ∨ S) → (Q ∨ S)).
 Proof.
-  pose proof (n2_53 R Q) as n2_53a.
-  pose proof (Perm1_4 Q R) as Perm1_4a.
-  Syll_as Perm1_4a n2_53a Ha.
-  pose proof (n2_38 S (¬ R) Q) as n2_38a.
-  now Syll_as Ha n2_38a Hb.
+  assert (S1 : R ∨ Q → (¬ R → Q)).
+  { exact (n2_53 R Q). }
+  assert (S2 : Q ∨ R → R ∨ Q).
+  { exact (Perm1_4 Q R). }
+  Syll_as S2 S1 S3.
+  assert (S4 : (¬ R → Q) → (¬ R ∨ S → Q ∨ S)).
+  { exact (n2_38 S (¬ R) Q). }
+  Syll_as S3 S4 S5.
+  exact S5.
 Qed.
+
 
 Theorem n2_81 (P Q R S : Prop) :
   (Q → (R → S)) → ((P ∨ Q) → ((P ∨ R) → (P ∨ S))).
 Proof.
-  pose proof (Sum1_6 P Q (R → S)) as Sum1_6a.
-  pose proof (n2_76 P R S) as n2_76a.
-  pose proof (Syll2_05 (P ∨ Q) (P ∨ (R → S)) ((P ∨ R) → (P ∨ S))) as Syll2_05a.
-  MP Syll2_05a n2_76a.
-  now Syll_as Sum1_6a Syll2_05a H.
+  assert (S1 : (Q → (R → S)) → (P ∨ Q → P ∨ (R → S))).
+  { exact (Sum1_6 P Q (R → S)). }
+  assert (S2 : P ∨ (R → S) → (P ∨ R → P ∨ S)).
+  { exact (n2_76 P R S). }
+  assert (S3 : (P ∨ (R → S) → (P ∨ R → P ∨ S)) → ((P ∨ Q → P ∨ (R → S)) → (P ∨ Q → (P ∨ R → P ∨ S)))).
+  { exact (Syll2_05 (P ∨ Q) (P ∨ (R → S)) (P ∨ R → P ∨ S)). }
+  assert (S4 : (P ∨ Q → P ∨ (R → S)) → (P ∨ Q → (P ∨ R → P ∨ S))).
+  { now MP S3 S2. }
+  Syll_as S1 S4 S5.
+  exact S5.
 Qed.
 
 Theorem n2_82 (P Q R S : Prop) :
   (P ∨ Q ∨ R) → ((P ∨ ¬ R ∨ S) → (P ∨ Q ∨ S)).
 Proof.
-  pose proof (n2_8 Q R S) as n2_8a.
-  pose proof (n2_81 P (Q ∨ R) (¬ R ∨ S) (Q ∨ S)) as n2_81a.
-  now MP n2_81a n2_8a.
+  assert (S1 : Q ∨ R → (¬ R ∨ S → Q ∨ S)).
+  { exact (n2_8 Q R S). }
+  assert (S2 : (Q ∨ R → (¬ R ∨ S → Q ∨ S)) → (P ∨ (Q ∨ R) → (P ∨ (¬ R ∨ S) → P ∨ (Q ∨ S)))).
+  { exact (n2_81 P (Q ∨ R) (¬ R ∨ S) (Q ∨ S)). }
+  assert (S3 : P ∨ (Q ∨ R) → (P ∨ (¬ R ∨ S) → P ∨ (Q ∨ S))).
+  { now MP S2 S1. }
+  exact S3.
 Qed.
 
 Theorem n2_83 (P Q R S : Prop) :
   (P → (Q → R)) → ((P → (R → S)) → (P → (Q → S))).
 Proof.
-  pose proof (n2_82 (¬ P) (¬ Q) R S) as n2_82a.
-  replace (¬ Q ∨ R) with (Q → R) in n2_82a.
-  replace (¬ P ∨ (Q → R)) with (P → Q → R) in n2_82a.
-  replace (¬ R ∨ S) with (R → S) in n2_82a.
-  replace (¬ P ∨ (R → S)) with (P → R → S) in n2_82a.
-  replace (¬ Q ∨ S) with (Q → S) in n2_82a.
-  replace (¬ P ∨ (Q → S)) with (P → Q → S) in n2_82a.
-  exact n2_82a.
-  all : now rewrite Impl1_01.
+  assert (S1 : ¬ P ∨ (¬ Q ∨ R) → (¬ P ∨ (¬ R ∨ S) → ¬ P ∨ (¬ Q ∨ S))).
+  { exact (n2_82 (¬ P) (¬ Q) R S). }
+  
+  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0))
+    as Impl1_01a.
+  
+  assert (S2 : (P → Q → R) → (P → R → S) → (P → Q → S)).
+  {
+    rewrite <- (Impl1_01a Q R) in S1.
+    rewrite <- (Impl1_01a P (Q → R)) in S1.
+    rewrite <- (Impl1_01a R S) in S1.
+    rewrite <- (Impl1_01a P (R → S)) in S1.
+    rewrite <- (Impl1_01a Q S) in S1.
+    now rewrite <- (Impl1_01a P (Q → S)) in S1.
+  }
+  exact S2.
 Qed.
 
 Theorem n2_85 (P Q R : Prop) :
   ((P ∨ Q) → (P ∨ R)) → (P ∨ (Q → R)).
 Proof.
-  pose proof (Add1_3 P Q) as Add1_3a.
-  pose proof (Syll2_06 Q (P ∨ Q) R) as Syll2_06a.
-  MP Syll2_06a Add1_3a.
-  pose proof (n2_55 P R) as n2_55a.
-  pose proof (Syll2_05 (P ∨ Q) (P ∨ R) R) as Syll2_05a.
-  Syll_as n2_55a Syll2_05a Ha.
-  pose proof (n2_83 (¬ P) ((P ∨ Q) → (P ∨ R)) ((P ∨ Q) → R) (Q → R)) as n2_83a.
-  MP n2_83a Ha.
-  pose proof (Comm2_04 (¬ P) (P ∨ Q → P ∨ R) (Q → R)) as Comm2_04a.
-  Syll_as n2_83a Comm2_04a Hb.
-  pose proof (n2_54 P (Q → R)) as n2_54a.
-  pose proof (Simp2_02 (¬ P) ((P ∨ Q → R) → (Q → R))) as Simp2_02a. 
-  MP Simp2_02a Syll2_06a.
-  MP Hb Simp2_02a.
-  now Syll_as Hb n2_54a Hc.
+  assert (S1 : Q → P ∨ Q).
+  { exact (Add1_3 P Q). }
+  assert (S2 : (Q → P ∨ Q) → ((P ∨ Q → R) → (Q → R))).
+  { exact (Syll2_06 Q (P ∨ Q) R). }
+  assert (S3 : (P ∨ Q → R) → (Q → R)).
+  { now MP S2 S1. }
+  assert (S4 : ¬ P → (P ∨ R → R)).
+  { exact (n2_55 P R). }
+  assert (S5 : (P ∨ R → R) → ((P ∨ Q → P ∨ R) → (P ∨ Q → R))).
+  { exact (Syll2_05 (P ∨ Q) (P ∨ R) R). }
+  Syll_as S4 S5 S6.
+  assert (S7 : (¬ P → ((P ∨ Q → P ∨ R) → (P ∨ Q → R))) → ((¬ P → ((P ∨ Q → R) → (Q → R))) → (¬ P → ((P ∨ Q → P ∨ R) → (Q → R))))). 
+  { exact (n2_83 (¬ P) (P ∨ Q → P ∨ R) (P ∨ Q → R) (Q → R)). }
+  assert (S8 : (¬ P → ((P ∨ Q → R) → (Q → R))) → (¬ P → ((P ∨ Q → P ∨ R) → (Q → R)))).
+  { now MP S7 S6. }
+  assert (S9 : (¬ P → ((P ∨ Q → P ∨ R) → (Q → R))) → ((P ∨ Q → P ∨ R) → (¬ P → (Q → R)))). 
+  { exact (Comm2_04 (¬ P) (P ∨ Q → P ∨ R) (Q → R)). }
+  Syll_as S8 S9 S10.
+  assert (S11 : ((P ∨ Q → R) → (Q → R)) → (¬ P → ((P ∨ Q → R) → (Q → R)))).
+  { exact (Simp2_02 (¬ P) ((P ∨ Q → R) → (Q → R))). }
+  assert (S12 : ¬ P → ((P ∨ Q → R) → (Q → R))).
+  { now MP S11 S3. }
+  assert (S13 : (P ∨ Q → P ∨ R) → (¬ P → (Q → R))).
+  { now MP S10 S12. }
+  assert (S14 : (¬ P → (Q → R)) → P ∨ (Q → R)).
+  { exact (n2_54 P (Q → R)). }
+  Syll_as S13 S14 S15.
+  exact S15.
 Qed.
-
+    
 Theorem n2_86 (P Q R : Prop) :
   ((P → Q) → (P → R)) → (P → (Q → R)).
 Proof.
-  pose proof (n2_85 (¬ P) Q R) as n2_85a.
-  replace (¬ P ∨ Q) with (P → Q) in n2_85a.
-  replace (¬ P ∨ R) with (P → R) in n2_85a.
-  replace (¬ P ∨ (Q → R)) with (P → Q → R) in n2_85a.
-  exact n2_85a.
-  all: now rewrite Impl1_01.
+  assert (S1 : (¬ P ∨ Q → ¬ P ∨ R) → ¬ P ∨ (Q → R)).
+  { exact (n2_85 (¬ P) Q R). }
+  
+  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0))
+    as Impl1_01a.
+  
+  assert (S2 : ((P → Q) → (P → R)) → (P → (Q → R))).
+  {
+    rewrite <- (Impl1_01a P Q) in S1.
+    rewrite <- (Impl1_01a P R) in S1.
+    now rewrite <- (Impl1_01a P (Q → R)) in S1.
+  }
+  exact S2.
 Qed.

--- a/pm/dagaz/ch2.v
+++ b/pm/dagaz/ch2.v
@@ -66,9 +66,7 @@ Qed.
 Theorem n2_07 (P : Prop) :
   P → (P ∨ P).
 Proof.
-  assert (S1 : P → (P ∨ P)).
-  { exact (Add1_3 P P). }
-  exact S1.
+  exact (Add1_3 P P).
 Qed.
 
 Theorem Id2_08 (P : Prop) :
@@ -90,11 +88,11 @@ Qed.
 Theorem n2_1 (P : Prop) :
   (¬ P) ∨ P.
 Proof.
-  assert (S1 : P → P).
-  { exact (Id2_08 P). }
-  assert (S2 : (¬ P) ∨ P).
-  { now rewrite Impl1_01 in S1. }
-  exact S2.
+  (* TOOLS *)
+  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
+  (* ******** *)
+  rewrite (Impl1_01a P P).
+  exact (Id2_08 P).
 Qed.
 
 Theorem n2_11 (P : Prop) :
@@ -271,23 +269,20 @@ Qed.
 Theorem n2_21 (P Q : Prop) :
   ¬ P → (P → Q).
 Proof.
-  assert (S1 : ¬ P → ¬ P ∨ Q).
-  { exact (n2_2 (¬ P) Q). }
-  assert (S2 : ¬ P → (P → Q)).
-  { now repeat rewrite <- Impl1_01 in S1. }
-  exact S2.
+  (* TOOLS *)
+  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
+  (* ******** *)
+  rewrite <- (Impl1_01a P Q).
+  exact (n2_2 (¬ P) Q).
 Qed.
 
 Theorem n2_24 (P Q : Prop) :
   P → (¬ P → Q).
 Proof.
-  assert (S1 : ¬ P → (P → Q)).
-  { exact (n2_21 P Q). }
-  assert (S2 : (¬ P → (P → Q)) → (P → (¬ P → Q))).
-  { exact (Comm2_04 (¬ P) P Q). }
-  assert (S3 : P → (¬ P → Q)).
-  { now MP S2 S1. }
-  exact S3.
+  (* TOOLS *)
+  set (λ P0 Q0 R0 : Prop, Comm2_04 P0 Q0 R0) as Comm2_04a.
+  (* ******** *)
+  exact (Comm2_04a (¬ P) P Q (n2_21 P Q)).
 Qed.
 
 Theorem n2_25 (P Q : Prop) :
@@ -314,21 +309,18 @@ Proof.
   (* TOOLS *)
   set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
   (* ******** *)
-  assert (S1 : ¬ P ∨ ((¬ P ∨ Q) → Q)).
-  { exact (n2_25 (¬ P) Q). }
-  assert (S2 : ¬ P ∨ ((P → Q) → Q)).
-  { now rewrite <- (Impl1_01a P Q) in S1. }
-  exact S2.
+  rewrite <- (Impl1_01a P Q).
+  exact (n2_25 (¬ P) Q).
 Qed.
 
 Theorem n2_27 (P Q : Prop) :
   P → ((P → Q) → Q).
 Proof.
-  assert (S1 : ¬ P ∨ ((P → Q) → Q)).
-  { exact (n2_26 P Q). }
-  assert (S2 : P → ((P → Q) → Q)).
-  { now repeat rewrite <- Impl1_01 in S1. }
-  exact S2.
+  (* TOOLS *)
+  set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
+  (* ******** *)
+  rewrite <- (Impl1_01a P ((P → Q) → Q)).
+  exact (n2_26 P Q).
 Qed.
 
 Theorem n2_3 (P Q R : Prop) :
@@ -398,12 +390,7 @@ Qed.
 Theorem n2_37 (P Q R : Prop) :
   (Q → R) → ((Q ∨ P) → (P ∨ R)).
 Proof.
-  assert (S1 : (P ∨ Q → P ∨ R) → (Q ∨ P → P ∨ R)).
-  { exact (Syll2_06 (Q ∨ P) (P ∨ Q) (P ∨ R) (Perm1_4 Q P)). }
-  assert (S2 : (Q → R) → (P ∨ Q → P ∨ R)).
-  { exact (Sum1_6 P Q R). }
-  Syll_as S2 S1 S3.
-  exact S3.
+  exact (λ H, Syll2_06 (Q ∨ P) (P ∨ Q) (P ∨ R) (Perm1_4 Q P) (Sum1_6 P Q R H)).
 Qed.
 
 Theorem n2_38 (P Q R : Prop) :
@@ -445,11 +432,9 @@ Proof.
   (* TOOLS *)
   set (λ P0 Q0 : Prop, eq_to_equiv (P0 → Q0) (¬ P0 ∨ Q0) (Impl1_01 P0 Q0)) as Impl1_01a.
   (* ******** *)
-  assert (S1 : ¬ P ∨ (¬ P ∨ Q) → ¬ P ∨ Q).
-  { exact (n2_4 (¬ P) Q). }
-  assert (S2 : (¬ P ∨ (P → Q)) → (P → Q)).
-  { now rewrite <- (Impl1_01a P Q) in S1. }
-  exact S2.
+  rewrite (Impl1_01a P Q).
+  rewrite <- (Impl1_01a P Q) at 1.
+  exact (n2_4 (¬ P) Q).
 Qed.
 
 Theorem n2_43 (P Q : Prop) :

--- a/pm/dagaz/ch2.v
+++ b/pm/dagaz/ch2.v
@@ -617,7 +617,7 @@ Proof.
     as Impl1_01a.
   
   assert (S4 : (¬ P → Q) → P ∨ Q).
-  { now rewrite (Impl1_01a (¬ P) Q) in S3. }
+  { now rewrite <-(Impl1_01a (¬ P) Q) in S3. }
   exact S4.
 Qed.
 


### PR DESCRIPTION
Relocated all local definitions (e.g., `set (λ P0 Q0 : Prop, ...)`) to the very beginning of the proofs.  And Make the structure clearer and the content more faithful to the original.
